### PR TITLE
Create merkle trees to submit onchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ module mev-sp-oracle
 go 1.19
 
 require (
+	github.com/miguelmota/go-solidity-sha3 v0.1.1
 	github.com/rs/zerolog v1.26.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.7.2
+	github.com/txaty/go-merkletree v0.1.15-0.20230105063604-9a402c177611
+	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e
 )
 
 require (
@@ -33,7 +36,7 @@ require (
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
-	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
+	github.com/txaty/gool v0.1.4 // indirect
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
+github.com/agiledragon/gomonkey/v2 v2.9.0 h1:PDiKKybR596O6FHW+RVSG0Z7uGCBNbmbUXh3uCNQ7Hc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -210,6 +211,8 @@ github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peK
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/miguelmota/go-solidity-sha3 v0.1.1 h1:3Y08sKZDtudtE5kbTBPC9RYJznoSYyWI9VD6mghU0CA=
+github.com/miguelmota/go-solidity-sha3 v0.1.1/go.mod h1:sax1FvQF+f71j8W1uUHMZn8NxKyl5rYLks2nqj8RFEw=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -283,6 +286,12 @@ github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
+github.com/txaty/go-merkletree v0.1.14 h1:kzfmLnECs/X3SwEosRLzYTwMK3jZgeikyPyY0K+G89E=
+github.com/txaty/go-merkletree v0.1.14/go.mod h1:cx6K7UXv2ogdVVq32kmVZ2vZnbdZqpC9CK5LGJvMbS0=
+github.com/txaty/go-merkletree v0.1.15-0.20230105063604-9a402c177611 h1:r09P8uboIff5jt48l82tBiROtwaqYm20tuoLwwwYJ2c=
+github.com/txaty/go-merkletree v0.1.15-0.20230105063604-9a402c177611/go.mod h1:cx6K7UXv2ogdVVq32kmVZ2vZnbdZqpC9CK5LGJvMbS0=
+github.com/txaty/gool v0.1.4 h1:3NwHLjdNsbITl3aqII8n8d4NYvOQE+3qt7cTLkeEAgM=
+github.com/txaty/gool v0.1.4/go.mod h1:zhUnrAMYUZXRYBq6dTofbCUn8OgA3OOKCFMeqGV2mu0=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/urfave/cli/v2 v2.10.2 h1:x3p8awjp/2arX+Nl/G2040AZpOCHS/eMJJ1/a+mye4Y=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/oracle/merklelizer.go
+++ b/oracle/merklelizer.go
@@ -1,3 +1,164 @@
 package oracle
 
-// All logic related to generation the merkle trees from the data we have
+import (
+	"encoding/hex"
+	"math/big"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	solsha3 "github.com/miguelmota/go-solidity-sha3"
+	mt "github.com/txaty/go-merkletree"
+	"golang.org/x/crypto/sha3"
+)
+
+type testData struct {
+	data []byte
+}
+
+func (t *testData) Serialize() ([]byte, error) {
+	log.Info("serializing", hex.EncodeToString(t.data))
+	return t.data, nil
+}
+
+func KeccakHash(data []byte) ([]byte, error) {
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write(data)
+	return hash.Sum(nil), nil
+}
+
+type Merklelizer struct {
+}
+
+func NewMerklelizer() *Merklelizer {
+	merklelizer := &Merklelizer{}
+	return merklelizer
+}
+
+type RawLeaf struct {
+	DepositAddress   string
+	PoolRecipient    string
+	ClaimableBalance *big.Int
+	UnbanBalance     *big.Int
+}
+
+// TODO: Add checks:
+// -New balance to claim matches what was sent to the pool, etc.
+
+// Aggregates all validators indexes that belong to the same pool recipient
+// AND deposit address.
+// TODO: This requires further testing
+func (merklelizer *Merklelizer) AggregateValidatorsIndexes(state *OracleState) []RawLeaf {
+	// Start all validators to be unprocessed
+	processed := make(map[uint64]bool)
+	for valIndex, _ := range state.PoolRecipientAddresses {
+		processed[valIndex] = false
+	}
+
+	allLeafs := make([]RawLeaf, 0)
+
+	// TODO: toLowerCase
+	// TODO Check sizes len(state.PendingRewards), len(state.ClaimableRewards), len(state.UnbanBalances), len(state.DepositAddresses), len(state.PoolRecipientAddresses)
+
+	// Iterate all validators
+	for valIndex, _ := range state.PoolRecipientAddresses {
+		poolRecipient := state.PoolRecipientAddresses[valIndex]
+		depositAddress := state.DepositAddresses[valIndex]
+
+		poolRecipientClaimableBalance := new(big.Int).SetUint64(0)
+		poolRecipientUnbanBalance := new(big.Int).SetUint64(0)
+
+		// Validator already processed
+		if processed[valIndex] {
+			continue
+		}
+
+		// Iterate all validators again and check if they have the same pool recipient and deposit address
+		for valIndex2, _ := range state.PoolRecipientAddresses {
+			poolRecipient2 := state.PoolRecipientAddresses[valIndex2]
+			depositAddress2 := state.DepositAddresses[valIndex2]
+
+			if poolRecipient == poolRecipient2 && depositAddress == depositAddress2 {
+				// flag as processed
+				processed[valIndex2] = true
+
+				poolRecipientClaimableBalance.Add(poolRecipientClaimableBalance, state.ClaimableRewards[valIndex2])
+				poolRecipientUnbanBalance.Add(poolRecipientUnbanBalance, state.UnbanBalances[valIndex2])
+			}
+		}
+		allLeafs = append(allLeafs, RawLeaf{
+			DepositAddress:   depositAddress,
+			PoolRecipient:    poolRecipient,
+			ClaimableBalance: poolRecipientClaimableBalance,
+			UnbanBalance:     poolRecipientUnbanBalance,
+		})
+	}
+
+	// Add one by one the ones that could not be aggregated (unprocessed)
+	for unprocIndex, _ := range processed {
+		if processed[unprocIndex] {
+			continue
+		}
+		allLeafs = append(allLeafs, RawLeaf{
+			DepositAddress:   state.DepositAddresses[unprocIndex],
+			PoolRecipient:    state.PoolRecipientAddresses[unprocIndex],
+			ClaimableBalance: state.ClaimableRewards[unprocIndex],
+			UnbanBalance:     state.UnbanBalances[unprocIndex],
+		})
+	}
+	return merklelizer.OrderByDepositAddress(allLeafs)
+}
+
+// Sort by deposit address
+func (merklelizer *Merklelizer) OrderByDepositAddress(leafs []RawLeaf) []RawLeaf {
+	sortedLeafs := make([]RawLeaf, len(leafs))
+	copy(sortedLeafs, leafs)
+	sort.Slice(sortedLeafs, func(i, j int) bool {
+		return sortedLeafs[i].DepositAddress < sortedLeafs[j].DepositAddress
+	})
+	return sortedLeafs
+}
+
+func (merklelizer *Merklelizer) GenerateTreeFromState(state *OracleState) *mt.MerkleTree {
+
+	blocks := make([]mt.DataBlock, 0)
+
+	orderedRawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+
+	for _, leaf := range orderedRawLeafs {
+		leafHash := solsha3.SoliditySHA3(
+			solsha3.Address(leaf.DepositAddress),
+			solsha3.Address(leaf.PoolRecipient),
+			solsha3.Uint256(leaf.ClaimableBalance),
+			solsha3.Uint256(leaf.UnbanBalance),
+		)
+		blocks = append(blocks, &testData{data: leafHash})
+	}
+
+	tree, err := mt.New(&mt.Config{
+		SortSiblingPairs: true,
+		HashFunc:         KeccakHash,
+		Mode:             mt.ModeTreeBuild,
+		DoNotHashLeaves:  true,
+	}, blocks)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tree
+
+	/*
+		for i := 0; i < len(blocks); i++ {
+			log.Info("rpfoo of block index :", i)
+			proof0, err := tree.GenerateProof(blocks[i])
+			if err != nil {
+				log.Fatal(err)
+			}
+			for j, proof := range proof0.Siblings {
+				_ = j
+				log.Info("proof0: ", hex.EncodeToString(proof))
+			}
+		}*/
+
+	// TODO: Update contract with root.
+	// TODO: Generate dump with proofs.
+}

--- a/oracle/merklelizer_test.go
+++ b/oracle/merklelizer_test.go
@@ -1,0 +1,417 @@
+package oracle
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"mev-sp-oracle/config"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GenerateTreeFromState(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0x1000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[0] = "0x0100000000000000000000000000000000000000"
+	state.ClaimableRewards[0] = big.NewInt(10000)
+	state.UnbanBalances[0] = big.NewInt(0)
+
+	state.DepositAddresses[1] = "0x2000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[1] = "0x0200000000000000000000000000000000000000"
+	state.ClaimableRewards[1] = big.NewInt(20000)
+	state.UnbanBalances[1] = big.NewInt(0)
+
+	state.DepositAddresses[2] = "0x3000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[2] = "0x0300000000000000000000000000000000000000"
+	state.ClaimableRewards[2] = big.NewInt(30000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	state.DepositAddresses[3] = "0x4000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[3] = "0x0400000000000000000000000000000000000000"
+	state.ClaimableRewards[3] = big.NewInt(40000)
+	state.UnbanBalances[3] = big.NewInt(10)
+
+	state.DepositAddresses[4] = "0x5000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[4] = "0x0500000000000000000000000000000000000000"
+	state.ClaimableRewards[4] = big.NewInt(50000)
+	state.UnbanBalances[4] = big.NewInt(0)
+
+	state.DepositAddresses[5] = "0x6000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[5] = "0x0600000000000000000000000000000000000000"
+	state.ClaimableRewards[5] = big.NewInt(60000)
+	state.UnbanBalances[5] = big.NewInt(0)
+
+	tree := merklelizer.GenerateTreeFromState(state)
+	require.Equal(t, "bcdf38cc9218047f9e86184199c880bfe80fc9eec2ecff0da3484217e6ccc898", hex.EncodeToString(tree.Root))
+
+}
+
+func Test_AggregateValidatorsIndexes_NoAggregation(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0x1000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[0] = "0x0100000000000000000000000000000000000000"
+	state.ClaimableRewards[0] = big.NewInt(10000)
+	state.UnbanBalances[0] = big.NewInt(0)
+
+	state.DepositAddresses[1] = "0x2000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[1] = "0x0200000000000000000000000000000000000000"
+	state.ClaimableRewards[1] = big.NewInt(20000)
+	state.UnbanBalances[1] = big.NewInt(0)
+
+	state.DepositAddresses[2] = "0x3000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[2] = "0x0300000000000000000000000000000000000000"
+	state.ClaimableRewards[2] = big.NewInt(30000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	state.DepositAddresses[3] = "0x4000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[3] = "0x0400000000000000000000000000000000000000"
+	state.ClaimableRewards[3] = big.NewInt(40000)
+	state.UnbanBalances[3] = big.NewInt(10)
+
+	state.DepositAddresses[4] = "0x5000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[4] = "0x0500000000000000000000000000000000000000"
+	state.ClaimableRewards[4] = big.NewInt(50000)
+	state.UnbanBalances[4] = big.NewInt(0)
+
+	state.DepositAddresses[5] = "0x6000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[5] = "0x0600000000000000000000000000000000000000"
+	state.ClaimableRewards[5] = big.NewInt(60000)
+	state.UnbanBalances[5] = big.NewInt(0)
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0x1000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0100000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(10000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x2000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0200000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(20000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x3000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0300000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(30000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x4000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0400000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(40000),
+			UnbanBalance:     new(big.Int).SetUint64(10),
+		},
+		{
+			DepositAddress:   "0x5000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0500000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(50000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x6000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0600000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(60000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+	}
+
+	rawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+	fmt.Println(rawLeafs)
+	require.Equal(t, expected, rawLeafs)
+}
+
+func Test_AggregateValidatorsIndexes_NoAggregationOrdered(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0x3000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[0] = "0x0300000000000000000000000000000000000000"
+	state.ClaimableRewards[0] = big.NewInt(30000)
+	state.UnbanBalances[0] = big.NewInt(0)
+
+	state.DepositAddresses[1] = "0x6000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[1] = "0x0600000000000000000000000000000000000000"
+	state.ClaimableRewards[1] = big.NewInt(60000)
+	state.UnbanBalances[1] = big.NewInt(0)
+
+	state.DepositAddresses[2] = "0x1000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[2] = "0x0100000000000000000000000000000000000000"
+	state.ClaimableRewards[2] = big.NewInt(10000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	state.DepositAddresses[3] = "0x4000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[3] = "0x0400000000000000000000000000000000000000"
+	state.ClaimableRewards[3] = big.NewInt(40000)
+	state.UnbanBalances[3] = big.NewInt(10)
+
+	state.DepositAddresses[4] = "0x5000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[4] = "0x0500000000000000000000000000000000000000"
+	state.ClaimableRewards[4] = big.NewInt(50000)
+	state.UnbanBalances[4] = big.NewInt(0)
+
+	state.DepositAddresses[5] = "0x2000000000000000000000000000000000000000"
+	state.PoolRecipientAddresses[5] = "0x0200000000000000000000000000000000000000"
+	state.ClaimableRewards[5] = big.NewInt(20000)
+	state.UnbanBalances[5] = big.NewInt(0)
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0x1000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0100000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(10000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x2000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0200000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(20000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x3000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0300000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(30000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x4000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0400000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(40000),
+			UnbanBalance:     new(big.Int).SetUint64(10),
+		},
+		{
+			DepositAddress:   "0x5000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0500000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(50000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+		{
+			DepositAddress:   "0x6000000000000000000000000000000000000000",
+			PoolRecipient:    "0x0600000000000000000000000000000000000000",
+			ClaimableBalance: new(big.Int).SetUint64(60000),
+			UnbanBalance:     new(big.Int).SetUint64(0),
+		},
+	}
+
+	rawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+	fmt.Println(rawLeafs)
+	require.Equal(t, expected, rawLeafs)
+}
+
+func Test_AggregateValidatorsIndexes_AggregationAll(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0xaa"
+	state.PoolRecipientAddresses[0] = "0xaa"
+	state.ClaimableRewards[0] = big.NewInt(30000)
+	state.UnbanBalances[0] = big.NewInt(0)
+
+	state.DepositAddresses[1] = "0xaa"
+	state.PoolRecipientAddresses[1] = "0xaa"
+	state.ClaimableRewards[1] = big.NewInt(60000)
+	state.UnbanBalances[1] = big.NewInt(0)
+
+	state.DepositAddresses[2] = "0xaa"
+	state.PoolRecipientAddresses[2] = "0xaa"
+	state.ClaimableRewards[2] = big.NewInt(10000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	state.DepositAddresses[3] = "0xaa"
+	state.PoolRecipientAddresses[3] = "0xaa"
+	state.ClaimableRewards[3] = big.NewInt(40000)
+	state.UnbanBalances[3] = big.NewInt(10)
+
+	state.DepositAddresses[4] = "0xaa"
+	state.PoolRecipientAddresses[4] = "0xaa"
+	state.ClaimableRewards[4] = big.NewInt(50000)
+	state.UnbanBalances[4] = big.NewInt(0)
+
+	state.DepositAddresses[5] = "0xaa"
+	state.PoolRecipientAddresses[5] = "0xaa"
+	state.ClaimableRewards[5] = big.NewInt(20000)
+	state.UnbanBalances[5] = big.NewInt(0)
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0xaa",
+			PoolRecipient:    "0xaa",
+			ClaimableBalance: new(big.Int).SetUint64(210000),
+			UnbanBalance:     new(big.Int).SetUint64(10),
+		},
+	}
+
+	rawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+	require.Equal(t, expected, rawLeafs)
+}
+
+func Test_AggregateValidatorsIndexes_Aggregation_And_Leftover(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0xaa"
+	state.PoolRecipientAddresses[0] = "0xaa"
+	state.ClaimableRewards[0] = big.NewInt(30000)
+	state.UnbanBalances[0] = big.NewInt(0)
+
+	state.DepositAddresses[1] = "0xaa"
+	state.PoolRecipientAddresses[1] = "0xaa"
+	state.ClaimableRewards[1] = big.NewInt(60000)
+	state.UnbanBalances[1] = big.NewInt(0)
+
+	state.DepositAddresses[2] = "0xaa"
+	state.PoolRecipientAddresses[2] = "0xaa"
+	state.ClaimableRewards[2] = big.NewInt(10000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	state.DepositAddresses[3] = "0xaa"
+	state.PoolRecipientAddresses[3] = "0xaa"
+	state.ClaimableRewards[3] = big.NewInt(40000)
+	state.UnbanBalances[3] = big.NewInt(10)
+
+	state.DepositAddresses[4] = "0xaa"
+	state.PoolRecipientAddresses[4] = "0xaa"
+	state.ClaimableRewards[4] = big.NewInt(50000)
+	state.UnbanBalances[4] = big.NewInt(0)
+
+	state.DepositAddresses[5] = "0xbb"
+	state.PoolRecipientAddresses[5] = "0xbb"
+	state.ClaimableRewards[5] = big.NewInt(500000)
+	state.UnbanBalances[5] = big.NewInt(500)
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0xaa",
+			PoolRecipient:    "0xaa",
+			ClaimableBalance: new(big.Int).SetUint64(190000),
+			UnbanBalance:     new(big.Int).SetUint64(10),
+		},
+		{
+			DepositAddress:   "0xbb",
+			PoolRecipient:    "0xbb",
+			ClaimableBalance: new(big.Int).SetUint64(500000),
+			UnbanBalance:     new(big.Int).SetUint64(500),
+		},
+	}
+
+	rawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+	require.Equal(t, expected, rawLeafs)
+}
+
+func Test_AggregateValidatorsIndexes_Aggregation_NoOrder(t *testing.T) {
+	merklelizer := NewMerklelizer()
+	state := NewOracleState(&config.Config{})
+
+	state.DepositAddresses[0] = "0xaa"
+	state.PoolRecipientAddresses[0] = "0xbb"
+	state.ClaimableRewards[0] = big.NewInt(30000)
+	state.UnbanBalances[0] = big.NewInt(10)
+
+	state.DepositAddresses[1] = "0xaa"
+	state.PoolRecipientAddresses[1] = "0xcc"
+	state.ClaimableRewards[1] = big.NewInt(60000)
+	state.UnbanBalances[1] = big.NewInt(15)
+
+	state.DepositAddresses[2] = "0xaa"
+	state.PoolRecipientAddresses[2] = "0xbb"
+	state.ClaimableRewards[2] = big.NewInt(10000)
+	state.UnbanBalances[2] = big.NewInt(0)
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0xaa",
+			PoolRecipient:    "0xbb",
+			ClaimableBalance: new(big.Int).SetUint64(40000),
+			UnbanBalance:     new(big.Int).SetUint64(10),
+		},
+		{
+			DepositAddress:   "0xaa",
+			PoolRecipient:    "0xcc",
+			ClaimableBalance: new(big.Int).SetUint64(60000),
+			UnbanBalance:     new(big.Int).SetUint64(15),
+		},
+	}
+
+	rawLeafs := merklelizer.AggregateValidatorsIndexes(state)
+	require.Equal(t, expected, rawLeafs)
+}
+
+func Test_OrderByDepositAddress(t *testing.T) {
+	merklelizer := NewMerklelizer()
+
+	leafs := []RawLeaf{
+		{
+			DepositAddress:   "0x30",
+			PoolRecipient:    "0xaaa",
+			ClaimableBalance: new(big.Int).SetUint64(1),
+			UnbanBalance:     new(big.Int).SetUint64(2),
+		},
+		{
+			DepositAddress:   "0x50",
+			PoolRecipient:    "0xbbb",
+			ClaimableBalance: new(big.Int).SetUint64(3),
+			UnbanBalance:     new(big.Int).SetUint64(4),
+		},
+		{
+			DepositAddress:   "0x10",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+		{
+			DepositAddress:   "0xa0",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+		{
+			DepositAddress:   "0x99",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+	}
+
+	expected := []RawLeaf{
+		{
+			DepositAddress:   "0x10",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+		{
+			DepositAddress:   "0x30",
+			PoolRecipient:    "0xaaa",
+			ClaimableBalance: new(big.Int).SetUint64(1),
+			UnbanBalance:     new(big.Int).SetUint64(2),
+		},
+		{
+			DepositAddress:   "0x50",
+			PoolRecipient:    "0xbbb",
+			ClaimableBalance: new(big.Int).SetUint64(3),
+			UnbanBalance:     new(big.Int).SetUint64(4),
+		},
+		{
+			DepositAddress:   "0x99",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+		{
+			DepositAddress:   "0xa0",
+			PoolRecipient:    "0xccc",
+			ClaimableBalance: new(big.Int).SetUint64(5),
+			UnbanBalance:     new(big.Int).SetUint64(6),
+		},
+	}
+
+	ordered := merklelizer.OrderByDepositAddress(leafs)
+	require.Equal(t, expected, ordered)
+}

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -42,9 +42,12 @@ type OracleState struct {
 	// TODO: Rough idea
 	//activeSubscriptions []uint64
 
-	PendingRewards   map[uint64]*big.Int // TODO add wei or gwei to all fucking variables.
-	ClaimableRewards map[uint64]*big.Int
-	UnbanBalance     map[uint64]*big.Int
+	PendingRewards map[uint64]*big.Int // TODO add wei or gwei to all fucking variables.
+
+	ClaimableRewards       map[uint64]*big.Int
+	UnbanBalances          map[uint64]*big.Int
+	DepositAddresses       map[uint64]string
+	PoolRecipientAddresses map[uint64]string
 
 	// TODO: Rename to states
 	validatorState map[uint64]int // TODO not sure if the enum has a type.
@@ -70,13 +73,15 @@ func NewOracleState(cfg *config.Config) *OracleState {
 		Network:     cfg.Network,
 		PoolAddress: cfg.PoolAddress,
 
-		PendingRewards:   make(map[uint64]*big.Int),
-		ClaimableRewards: make(map[uint64]*big.Int),
-		UnbanBalance:     make(map[uint64]*big.Int),
-		validatorState:   make(map[uint64]int),
-		proposedBlocks:   make(map[uint64][]uint64),
-		missedBlocks:     make(map[uint64][]uint64),
-		wrongFeeBlocks:   make(map[uint64][]uint64),
+		PendingRewards:         make(map[uint64]*big.Int),
+		ClaimableRewards:       make(map[uint64]*big.Int),
+		UnbanBalances:          make(map[uint64]*big.Int),
+		DepositAddresses:       make(map[uint64]string),
+		PoolRecipientAddresses: make(map[uint64]string),
+		validatorState:         make(map[uint64]int),
+		proposedBlocks:         make(map[uint64][]uint64),
+		missedBlocks:           make(map[uint64][]uint64),
+		wrongFeeBlocks:         make(map[uint64][]uint64),
 	}
 }
 
@@ -87,7 +92,7 @@ func (state *OracleState) AddSubscriptionIfNotAlready(valIndex uint64) {
 	}
 	state.PendingRewards[valIndex] = big.NewInt(0)
 	state.ClaimableRewards[valIndex] = big.NewInt(0)
-	state.UnbanBalance[valIndex] = big.NewInt(0)
+	state.UnbanBalances[valIndex] = big.NewInt(0)
 	state.validatorState[valIndex] = Active
 	state.proposedBlocks[valIndex] = make([]uint64, 0)
 	state.missedBlocks[valIndex] = make([]uint64, 0)
@@ -128,7 +133,7 @@ func (state *OracleState) ResetPendingRewards(valIndex uint64) {
 }
 
 func (state *OracleState) SetUnbanBalance(valIndex uint64, amount *big.Int) {
-	state.UnbanBalance[valIndex] = amount
+	state.UnbanBalances[valIndex] = amount
 }
 
 func (state *OracleState) GetState(valIndex uint64) int {

--- a/oracle/utils.go
+++ b/oracle/utils.go
@@ -35,3 +35,15 @@ func SumAndSaturate(a *big.Int, b *big.Int, saturate *big.Int) *big.Int {
 	}
 	return aPlusB
 }
+
+func GetUniqueElements(arr []string) []string {
+	result := []string{}
+	encountered := map[string]bool{}
+	for v := range arr {
+		encountered[arr[v]] = true
+	}
+	for key, _ := range encountered {
+		result = append(result, key)
+	}
+	return result
+}

--- a/oracle/utils_test.go
+++ b/oracle/utils_test.go
@@ -55,7 +55,7 @@ func Test_GetUniqueElements(t *testing.T) {
 			"0xaaa",
 			"0xbbb",
 		})
-	require.Equal(t, []string{"0xaaa", "0xbbb"}, test1)
+	require.ElementsMatch(t, []string{"0xaaa", "0xbbb"}, test1)
 
 	test2 := GetUniqueElements(
 		[]string{
@@ -64,13 +64,13 @@ func Test_GetUniqueElements(t *testing.T) {
 			"0xaaa",
 			"0xaaa",
 		})
-	require.Equal(t, []string{"0xaaa"}, test2)
+	require.ElementsMatch(t, []string{"0xaaa"}, test2)
 
 	test3 := GetUniqueElements(
 		[]string{
 			"0xaaa",
 		})
-	require.Equal(t, []string{"0xaaa"}, test3)
+	require.ElementsMatch(t, []string{"0xaaa"}, test3)
 
 	test4 := GetUniqueElements(
 		[]string{
@@ -78,5 +78,5 @@ func Test_GetUniqueElements(t *testing.T) {
 			"0xbbb",
 			"0xccc",
 		})
-	require.Equal(t, []string{"0xaaa", "0xbbb", "0xccc"}, test4)
+	require.ElementsMatch(t, []string{"0xaaa", "0xbbb", "0xccc"}, test4)
 }

--- a/oracle/utils_test.go
+++ b/oracle/utils_test.go
@@ -46,3 +46,37 @@ func Test_SumAndSaturate(t *testing.T) {
 	test3 := SumAndSaturate(big.NewInt(500), big.NewInt(700), big.NewInt(1000000))
 	require.Equal(t, big.NewInt(1200), test3)
 }
+
+func Test_GetUniqueElements(t *testing.T) {
+	test1 := GetUniqueElements(
+		[]string{
+			"0xaaa",
+			"0xaaa",
+			"0xaaa",
+			"0xbbb",
+		})
+	require.Equal(t, []string{"0xaaa", "0xbbb"}, test1)
+
+	test2 := GetUniqueElements(
+		[]string{
+			"0xaaa",
+			"0xaaa",
+			"0xaaa",
+			"0xaaa",
+		})
+	require.Equal(t, []string{"0xaaa"}, test2)
+
+	test3 := GetUniqueElements(
+		[]string{
+			"0xaaa",
+		})
+	require.Equal(t, []string{"0xaaa"}, test3)
+
+	test4 := GetUniqueElements(
+		[]string{
+			"0xaaa",
+			"0xbbb",
+			"0xccc",
+		})
+	require.Equal(t, []string{"0xaaa", "0xbbb", "0xccc"}, test4)
+}


### PR DESCRIPTION
- [x] Add new module that contains all merkle trees (creation and proof generation) logic.
- [x] Aggregate claimable/unban balance per poolRecipient/depositAddress, to claim multiple validator indexes at once.
- [x] Calculate merkle root and proofs of the balances.