### PR TITLE
Add dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage of ./mev-sp-oracle:
 
 ## Goerli Example
 
+Use `--dry-run` to avoid updating the contract, useful when you want to recreate the state to verify the merkle roots.
 ```console
 $ go build
 $ ./mev-sp-oracle \

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	CheckPointSizeInSlots uint64
 	PostgresEndpoint      string
 	DeployerPrivateKey    string
+	DryRun                bool
 
 	// Debug flags, never use in production
 	DebugHardcodedSubscriptions []uint64
@@ -32,12 +33,13 @@ func NewCliConfig() (*Config, error) {
 	var version = flag.Bool("version", false, "Prints the release version and exits")
 	var consensusEndpoint = flag.String("consensus-endpoint", "", "Ethereum consensus endpoint")
 	var executionEndpoint = flag.String("execution-endpoint", "", "Ethereum execution endpoint")
-	var network = flag.String("network", "mainnet", "Network to run in: mainnet|goerli")
+	var network = flag.String("network", "", "Network to run in: mainnet|goerli")
 	var poolAddress = flag.String("pool-address", "", "Address of the smoothing pool contract")
 	var deployedSlot = flag.Uint64("deployed-slot", 0, "Deployed slot of the smart contract: slot, not block")
 	var checkPointSizeInSlots = flag.Uint64("checkpoint-size", 0, "Size in slots for each checkpoint, used to generate dumps and update merkle roots")
 	var postgresEndpoint = flag.String("postgres-endpoint", "", "Postgres endpoint")
 	var deployerPrivateKey = flag.String("deployer-private-key", "", "Private key of the deployer account")
+	var dryRun = flag.Bool("dry-run", false, "If enabled, the pool contract will not be updated")
 
 	// Debug flags, never use in production
 	var debugHardcodedSubscriptionsFile = flag.String("debug-subscriptions-file", "", "Path to file containing a list of hardcoded validator indexes, one per line")
@@ -69,6 +71,12 @@ func NewCliConfig() (*Config, error) {
 		DebugHardcodedSubscriptions: debugHardcodedSubscriptions,
 		PostgresEndpoint:            *postgresEndpoint,
 		DeployerPrivateKey:          *deployerPrivateKey,
+		DryRun:                      *dryRun,
+	}
+	if conf.DryRun {
+		log.Warn("The pool contract will NOT be updated, running in dry-run mode")
+	} else {
+		log.Warn("The pool contract will be updated. Make sure it has balance to cover tx fees")
 	}
 	logConfig(conf)
 	return conf, nil
@@ -85,6 +93,7 @@ func logConfig(cfg *Config) {
 		"PostgresEndpoint":            cfg.PostgresEndpoint,
 		"DebugHardcodedSubscriptions": cfg.DebugHardcodedSubscriptions,
 		"DeployerPrivateKey":          "TODO: use a file with protected password",
+		"DryRun":                      cfg.DryRun,
 	}).Info("Cli Config:")
 }
 

--- a/contract/operatons.go
+++ b/contract/operatons.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -46,7 +47,7 @@ func (o *Operations) UpdateContractMerkleRoot(newMerkleRoot string) {
 	}
 	copy(newMerkleRootBytes[:], common.Hex2Bytes(newMerkleRoot))
 
-	log.Info("new merkle root:", newMerkleRootBytes)
+	log.Info("new merkle root:", hex.EncodeToString(newMerkleRootBytes[:]))
 
 	privateKey, err := crypto.HexToECDSA(o.cfg.DeployerPrivateKey)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -124,7 +124,9 @@ func mainLoop(oracle *oracle.Oracle, fetcher *oracle.Fetcher, cfg *config.Config
 		if (oracle.State.Slot-cfg.DeployedSlot)%cfg.CheckPointSizeInSlots == 0 {
 			log.Info("Checkpoint reached, slot: ", oracle.State.Slot)
 			err, mRoot := oracle.State.DumpOracleStateToDatabase()
-			oracle.Operations.UpdateContractMerkleRoot(mRoot)
+			if !cfg.DryRun {
+				oracle.Operations.UpdateContractMerkleRoot(mRoot)
+			}
 			// TODO: By now just panic
 			if err != nil {
 				log.Fatal("Failed dumping oracle state to db: ", err)

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -262,7 +262,13 @@ func (state *OracleState) DumpOracleStateToDatabase() (error, string) { // TOOD:
 
 	// TODO: Add also validator key on top of the index
 	for valIndex, _ := range state.ValidatorState {
+		log.Info("Generating root for deposit: ", state.DepositAddresses[valIndex])
 		block := depositToLeaf[state.DepositAddresses[valIndex]]
+		serrr, err := block.Serialize()
+		if err != nil {
+			log.Fatal("Error serializing block", err)
+		}
+		log.Info("Hash of leaf is: ", hex.EncodeToString(serrr))
 		proof, err := tree.GenerateProof(block)
 		if err != nil {
 			log.Fatal("Error generating proof", err)


### PR DESCRIPTION
* Add dry-run mode (`dry-run` cli flag). When enabled, contract is not updated. Useful when you want to recreate the state.