### PR TITLE
Introduce retry logic

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -148,6 +148,7 @@ type ApiService struct {
 func NewApiService(cfg config.Config, state *oracle.OracleState, onchain *oracle.Onchain) *ApiService {
 	postgres, err := postgres.New(cfg.PostgresEndpoint)
 	if err != nil {
+		// TODO: Return error instead of fatal
 		log.Fatal(err)
 	}
 
@@ -237,11 +238,11 @@ func (m *ApiService) handlePoolStatistics(w http.ResponseWriter, req *http.Reque
 	// has to catch up
 	//oracleMerkleRoot := "0x" + m.OracleState.LatestCommitedState.MerkleRoot
 
-	contractMerkleRoot, err := m.Onchain.GetMerkleRoot()
-	if err != nil {
+	contractMerkleRoot := m.Onchain.GetContractMerkleRoot()
+	/*if err != nil {
 		m.respondError(w, http.StatusBadRequest, "could not get latest merkle root from chain")
 		return
-	}
+	}*/
 
 	totalSubscribed := uint64(0)
 	totalActive := uint64(0)
@@ -406,11 +407,12 @@ func (m *ApiService) handleLatestMerkleRoot(w http.ResponseWriter, req *http.Req
 	// This is the latest merkle root tracked from the oracle.
 	//oracleMerkleRoot := "0x" + m.OracleState.LatestCommitedState.MerkleRoot
 
-	contractMerkleRoot, err := m.Onchain.GetMerkleRoot()
-	if err != nil {
-		m.respondError(w, http.StatusBadRequest, "could not get latest merkle root from chain")
-		return
-	}
+	contractMerkleRoot := m.Onchain.GetContractMerkleRoot()
+	/*
+		if err != nil {
+			m.respondError(w, http.StatusBadRequest, "could not get latest merkle root from chain")
+			return
+		}*/
 	m.respondOK(w, httpOkMerkleRoot{
 		MerkleRoot: contractMerkleRoot,
 	})

--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,7 @@ import (
 
 // These are the retry options when an api call involves external call to the beacon node
 // or execution client. The idea is to try once, and fail fast.
+// Use this for all onchain calls, otherwise defaultRetryOpts will be aplied
 var apiRetryOpts = []retry.Option{
 	retry.Attempts(1),
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"crypto/ecdsa"
+	"errors"
 	"flag"
 	"os"
 	"strconv"
@@ -56,53 +57,53 @@ func NewCliConfig() (*Config, error) {
 
 	// Mandatory flag
 	if *poolFeesAddress == "" {
-		log.Fatal("pool-fees-address flag is not present")
+		return nil, errors.New("pool-fees-address flag is not present")
 	}
 
 	// Mandatory flag
 	if *poolFeesPercent == -1 {
-		log.Fatal("pool-fees-percent flag is not present")
+		return nil, errors.New("pool-fees-percent flag is not present")
 	}
 
 	if *poolFeesPercent < 0 || *poolFeesPercent > 100 {
-		log.Fatal("pool-fees-percent must be between 0 and 100")
+		return nil, errors.New("pool-fees-percent must be between 0 and 100")
 	}
 
 	// Mandatory flag
 	if *network != "mainnet" && *network != "goerli" {
-		log.Fatal("wrong network provided, must be mainnet or goerli")
+		return nil, errors.New("wrong network provided, must be mainnet or goerli")
 	}
 
 	if *poolFeesAddress == *poolAddress {
-		log.Fatal("pool-fees-address and pool-address can't be equal")
+		return nil, errors.New("pool-fees-address and pool-address can't be equal")
 	}
 
 	if !*dryRun && *deployerPrivateKey == "" {
-		log.Fatal("you must provide a private key to update the contract root")
+		return nil, errors.New("you must provide a private key to update the contract root")
 	}
 
 	if *dryRun && *deployerPrivateKey != "" {
-		log.Fatal("dry-run mode specified buy also provided a deployer-private-key")
+		return nil, errors.New("dry-run mode specified buy also provided a deployer-private-key")
 	}
 
 	// Check deployerPrivateKey is valid
 	pKey, err := crypto.HexToECDSA(*deployerPrivateKey)
 	if err != nil {
-		log.Fatal("wrong private key, couldn't parse it: ", err)
+		return nil, errors.New("wrong private key, couldn't parse it: " + err.Error())
 	}
 
 	publicKey := pKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		return nil, errors.New("error casting public key to ECDSA: " + err.Error())
 	}
 
 	if !common.IsHexAddress(*poolAddress) {
-		log.Fatal("pool-address: ", *poolAddress, " is not a valid address")
+		return nil, errors.New("pool-address: " + *poolAddress + " is not a valid address")
 	}
 
 	if !common.IsHexAddress(*poolFeesAddress) {
-		log.Fatal("pool-fees-address: ", *poolFeesAddress, " is not a valid address")
+		return nil, errors.New("pool-fees-address: " + *poolFeesAddress + " is not a valid address")
 	}
 
 	conf := &Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,22 +4,15 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
-func CreateMockKeysFile(customKeysFile string, content string) {
+func CreateMockKeysFile(t *testing.T, customKeysFile string, content string) {
 	f, err := os.Create(customKeysFile)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = f.WriteString(content)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	f.Close()
 }
 
@@ -27,7 +20,7 @@ func Test_Legacy_0_Tx_Decode(t *testing.T) {
 	// Test file containing 4 validator indexes, one per line
 	fileName := "hardcoded_subscriptions.txt"
 	someValidatorIndexes := "1234\n2132\n890\n2343"
-	CreateMockKeysFile(fileName, someValidatorIndexes)
+	CreateMockKeysFile(t, fileName, someValidatorIndexes)
 	defer os.Remove(fileName)
 
 	indexes, err := ReadHardcodedSubscriptions(fileName)
@@ -41,7 +34,7 @@ func Test_Legacy_0_Tx_Decode(t *testing.T) {
 	// Test file containing 4 validator indexes, one per line, with extra line/space
 	fileName2 := "hardcoded_subscriptions.txt"
 	someValidatorIndexes2 := "1\n22\n8\n2\n " // <- extra line/space
-	CreateMockKeysFile(fileName2, someValidatorIndexes2)
+	CreateMockKeysFile(t, fileName2, someValidatorIndexes2)
 	defer os.Remove(fileName2)
 
 	indexes2, err := ReadHardcodedSubscriptions(fileName2)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dappnode/mev-sp-oracle
 go 1.19
 
 require (
+	github.com/avast/retry-go/v4 v4.3.3
 	github.com/gorilla/mux v1.8.0
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/jackc/pgx/v4 v4.17.2
@@ -10,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.26.1
 	github.com/sirupsen/logrus v1.9.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/txaty/go-merkletree v0.1.15-0.20230105063604-9a402c177611
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 )

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/attestantio/go-eth2-client v0.15.7 h1:0v7+Z2RZ8bNtU/0mfppXzLiYv+6a8pe2wKyA6CU9jwQ=
 github.com/attestantio/go-eth2-client v0.15.7/go.mod h1:/Oh6YTuHmHhgLN/ZnQRKHGc7HdIzGlDkI2vjNZvOsvA=
+github.com/avast/retry-go/v4 v4.3.3 h1:G56Bp6mU0b5HE1SkaoVjscZjlQb0oy4mezwY/cGH19w=
+github.com/avast/retry-go/v4 v4.3.3/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -358,14 +360,16 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=

--- a/main.go
+++ b/main.go
@@ -36,10 +36,13 @@ func main() {
 	oracleInstance := oracle.NewOracle(cfg, onchain)
 	api := api.NewApiService(*cfg, oracleInstance.State, onchain)
 
-	balnace := onchain.GetEthBalance(cfg.PoolAddress)
+	balance, err := onchain.GetEthBalance(cfg.PoolAddress)
+	if err != nil {
+		log.Fatal("Could not get pool address balance: " + err.Error())
+	}
 	log.WithFields(log.Fields{
 		"address":     cfg.PoolAddress,
-		"balance_wei": balnace,
+		"balance_wei": balance,
 	}).Info("Pool Address Balance")
 
 	// TODO: Try to resume syncing from latest known state from file

--- a/main.go
+++ b/main.go
@@ -29,7 +29,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	onchain := oracle.NewOnchain(*cfg)
+	onchain, err := oracle.NewOnchain(*cfg)
+	if err != nil {
+		log.Fatal("could not create new onchain object:", err)
+	}
 	oracleInstance := oracle.NewOracle(cfg, onchain)
 	api := api.NewApiService(*cfg, oracleInstance.State, onchain)
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	onchain, err := oracle.NewOnchain(*cfg)
 	if err != nil {
-		log.Fatal("could not create new onchain object:", err)
+		log.Fatal("Could not create new onchain object: ", err)
 	}
 	oracleInstance := oracle.NewOracle(cfg, onchain)
 	api := api.NewApiService(*cfg, oracleInstance.State, onchain)
@@ -74,7 +74,11 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *confi
 
 	for {
 		// Ensure that the nodes we are using are in sync with the blockchain (consensus + execution)
-		if !onchain.AreNodesInSync() {
+		inSync, err := onchain.AreNodesInSync()
+		if err != nil {
+			log.Fatal("Could not get nodes in sync status:", err)
+		}
+		if !inSync {
 			log.Error("Nodes are not in sync, skipping until in sync")
 			time.Sleep(15 * time.Second)
 			continue

--- a/oracle/block_test.go
+++ b/oracle/block_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/ethereum/go-ethereum/core/types"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,7 +118,7 @@ func Test_Bellatrix_GoerliTx_Decode(t *testing.T) {
 func Test_GetProperTip_Mainnet_Slot_5320341(t *testing.T) {
 	// Decode a a hardcode block/header/receipts
 	fileName := "bellatrix_slot_5320341_mainnet"
-	block, header, receipts := LoadBlockHeaderReceiptsBellatrix(fileName)
+	block, header, receipts := LoadBlockHeaderReceiptsBellatrix(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Bellatrix: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -134,7 +133,7 @@ func Test_GetProperTip_Mainnet_Slot_5320341(t *testing.T) {
 // are a bit different.
 func Test_GetProperTip_Mainnet_Slot_5344344(t *testing.T) {
 	fileName := "bellatrix_slot_5344344_mainnet"
-	block, header, receipts := LoadBlockHeaderReceiptsBellatrix(fileName)
+	block, header, receipts := LoadBlockHeaderReceiptsBellatrix(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Bellatrix: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -150,7 +149,7 @@ func Test_GetProperTip_Mainnet_Slot_5344344(t *testing.T) {
 
 func Test_GetProperTip_Goerli_Slot_5214302(t *testing.T) {
 	fileName := "capella_slot_5214302_goerli"
-	block, header, receipts := LoadBlockHeaderReceiptsCapella(fileName)
+	block, header, receipts := LoadBlockHeaderReceiptsCapella(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Capella: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -161,7 +160,7 @@ func Test_GetProperTip_Goerli_Slot_5214302(t *testing.T) {
 
 func Test_GetMevReward_Goerli_Slot_5214321(t *testing.T) {
 	fileName := "capella_slot_5214321_goerli"
-	block, header, receipts := LoadBlockHeaderReceiptsCapella(fileName)
+	block, header, receipts := LoadBlockHeaderReceiptsCapella(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Capella: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -179,7 +178,7 @@ func Test_GetMevReward_Goerli_Slot_5214321(t *testing.T) {
 
 func Test_MevReward_Slot_5320342(t *testing.T) {
 	fileName := "bellatrix_slot_5320342_mainnet"
-	block, _, _ := LoadBlockHeaderReceiptsBellatrix(fileName)
+	block, _, _ := LoadBlockHeaderReceiptsBellatrix(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Bellatrix: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -206,7 +205,7 @@ func Test_MevReward_Slot_5320342(t *testing.T) {
 // Test donated amount to a given address in a block
 func Test_DonatedAmountInWei_Slot_5320342(t *testing.T) {
 	fileName := "bellatrix_slot_5320342_mainnet"
-	block, _, _ := LoadBlockHeaderReceiptsBellatrix(fileName)
+	block, _, _ := LoadBlockHeaderReceiptsBellatrix(t, fileName)
 	extendedBlock := spec.VersionedSignedBeaconBlock{Bellatrix: &block}
 	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
 
@@ -222,77 +221,53 @@ func Test_DonatedAmountInWei_Slot_5320342(t *testing.T) {
 }
 
 // Util to load from file
-func LoadBlockHeaderReceiptsBellatrix(file string) (bellatrix.SignedBeaconBlock, types.Header, []*types.Receipt) {
+func LoadBlockHeaderReceiptsBellatrix(t *testing.T, file string) (bellatrix.SignedBeaconBlock, types.Header, []*types.Receipt) {
 	blockJson, err := os.Open("../mock/block_" + file)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	blockByte, err := ioutil.ReadAll(blockJson)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	var bellatrixblock bellatrix.SignedBeaconBlock
 	err = bellatrixblock.UnmarshalJSON(blockByte)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var headerBlock types.Header
 	headerJson, err := os.Open("../mock/header_" + file)
 	headerByte, err := ioutil.ReadAll(headerJson)
 	err = headerBlock.UnmarshalJSON(headerByte)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var txReceipts []*types.Receipt
 	txReceiptsJson, err := os.Open("../mock/txreceipts_" + file)
 	txReceiptsByte, err := ioutil.ReadAll(txReceiptsJson)
 	err = json.Unmarshal(txReceiptsByte, &txReceipts)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return bellatrixblock, headerBlock, txReceipts
 }
 
-func LoadBlockHeaderReceiptsCapella(file string) (capella.SignedBeaconBlock, types.Header, []*types.Receipt) {
+func LoadBlockHeaderReceiptsCapella(t *testing.T, file string) (capella.SignedBeaconBlock, types.Header, []*types.Receipt) {
 	blockJson, err := os.Open("../mock/block_" + file)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 	blockByte, err := ioutil.ReadAll(blockJson)
-	if err != nil {
-		log.Fatal("could not read json file: ", err)
-	}
+	require.NoError(t, err)
 	var capellaBlock capella.SignedBeaconBlock
 	err = capellaBlock.UnmarshalJSON(blockByte)
-	if err != nil {
-		log.Fatal("could not unmarshal json into capella signed block:", err)
-	}
+	require.NoError(t, err)
 
 	var headerBlock types.Header
 	headerJson, err := os.Open("../mock/header_" + file)
-	if err != nil {
-		log.Fatal("could not open header file: ", err)
-	}
+	require.NoError(t, err)
 	fmt.Println("jeader", headerJson)
 	headerByte, err := ioutil.ReadAll(headerJson)
-	if err != nil {
-		log.Fatal("could not read header file: ", err)
-	}
+	require.NoError(t, err)
 	err = headerBlock.UnmarshalJSON(headerByte)
-	if err != nil {
-		log.Fatal("could not unmarshal header block: ", err)
-	}
+	require.NoError(t, err)
 
 	var txReceipts []*types.Receipt
 	txReceiptsJson, err := os.Open("../mock/txreceipts_" + file)
 	txReceiptsByte, err := ioutil.ReadAll(txReceiptsJson)
 	err = json.Unmarshal(txReceiptsByte, &txReceipts)
-	if err != nil {
-		log.Fatal("could not unmarshal tx receipt: ", err)
-	}
+	require.NoError(t, err)
 
 	return capellaBlock, headerBlock, txReceipts
 }

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -164,37 +164,37 @@ func (f *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
 	return false, nil
 }
 
-// TODO: rename to getConsensusblock?
-func (f *Onchain) GetBlockAtSlot(slot uint64) (*spec.VersionedSignedBeaconBlock, error) {
-
-	// TODO: set custom timeouts
+func (f *Onchain) GetConsensusBlockAtSlot(slot uint64, opts ...retry.Option) (*spec.VersionedSignedBeaconBlock, error) {
 	slotStr := strconv.FormatUint(slot, 10)
 	var signedBeaconBlock *spec.VersionedSignedBeaconBlock
 	var err error
 
-	for {
+	err = retry.Do(func() error {
 		signedBeaconBlock, err = f.ConsensusClient.SignedBeaconBlock(context.Background(), slotStr)
 		if err != nil {
-			log.Warn("Error fetching block at slot ", slot, ": ", err, " Retrying in 15 seconds...")
-			time.Sleep(15 * time.Second)
-			continue
+			return errors.New("Error fetching block at slot " + slotStr + ": " + err.Error())
 		}
-		break
+		return nil
+	}, GetRetryOpts(opts)...)
+
+	if err != nil {
+		return nil, errors.New("Could not fetch block at slot " + slotStr + ": " + err.Error())
 	}
 	return signedBeaconBlock, err
 }
 
-func (f *Onchain) GetProposalDuty(slot uint64) (*api.ProposerDuty, error) {
-	// Hardcoded
+func (f *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*api.ProposerDuty, error) {
+	// Hardcoded value, slots in an epoch
 	slotsInEpoch := uint64(32)
 	epoch := slot / slotsInEpoch
 	slotWithinEpoch := slot % slotsInEpoch
+	slotStr := strconv.FormatUint(slot, 10)
 
 	// If cache hit, return the result
 	if ProposalDutyCache.Epoch == epoch {
-		// Health check that should never happen
+		// Sanity check that should never happen
 		if ProposalDutyCache.Epoch != uint64(ProposalDutyCache.Duties[slotWithinEpoch].Slot/phase0.Slot(slotsInEpoch)) {
-			log.Fatal("Proposal duty epoch does not match when converting slot to epoch")
+			return nil, errors.New("Proposal duty epoch does not match when converting slot to epoch")
 		}
 		return ProposalDutyCache.Duties[slotWithinEpoch], nil
 	}
@@ -204,39 +204,44 @@ func (f *Onchain) GetProposalDuty(slot uint64) (*api.ProposerDuty, error) {
 	var duties []*api.ProposerDuty
 	var err error
 
-	for {
+	err = retry.Do(func() error {
 		duties, err = f.ConsensusClient.ProposerDuties(
-			context.Background(),
-			phase0.Epoch(epoch),
-			indexes)
+			context.Background(), phase0.Epoch(epoch), indexes)
 		if err != nil {
-			log.Warn("Error fetching proposer duties for epoch ", epoch, ": ", err, " Retrying in 15 seconds...")
-			time.Sleep(15 * time.Second)
-			continue
+			return errors.New("Error fetching proposal duties at slot " + slotStr + ": " + err.Error())
 		}
-		break
+		return nil
+	}, GetRetryOpts(opts)...)
+
+	if err != nil {
+		return nil, errors.New("Error fetching proposal duties at slot " + slotStr + ": " + err.Error())
 	}
 
-	// Store result in cache
+	// If success, store result in cache
 	ProposalDutyCache = EpochDuties{epoch, duties}
 
 	return duties[slotWithinEpoch], nil
 }
 
 // This function is expensive as gets every tx receipt from the block. Use only if needed
-func (f *Onchain) GetExecHeaderAndReceipts(blockNumber *big.Int, rawTxs []bellatrix.Transaction) (*types.Header, []*types.Receipt, error) {
+func (f *Onchain) GetExecHeaderAndReceipts(
+	blockNumber *big.Int,
+	rawTxs []bellatrix.Transaction,
+	opts ...retry.Option) (*types.Header, []*types.Receipt, error) {
 
 	var header *types.Header
 	var err error
 
-	for {
+	err = retry.Do(func() error {
 		header, err = f.ExecutionClient.HeaderByNumber(context.Background(), blockNumber)
 		if err != nil {
-			log.Warn("Error fetching header at block ", blockNumber, ": ", err, " Retrying in 15 seconds...")
-			time.Sleep(15 * time.Second)
-			continue
+			return errors.New("Error fetching header for block " + blockNumber.String() + ": " + err.Error())
 		}
-		break
+		return nil
+	}, GetRetryOpts(opts)...)
+
+	if err != nil {
+		return nil, nil, errors.New("Could not fetch header for block " + blockNumber.String() + ": " + err.Error())
 	}
 
 	var receipts []*types.Receipt
@@ -247,14 +252,17 @@ func (f *Onchain) GetExecHeaderAndReceipts(blockNumber *big.Int, rawTxs []bellat
 			log.Fatal(err)
 		}
 		var receipt *types.Receipt
-		for {
+
+		err = retry.Do(func() error {
 			receipt, err = f.ExecutionClient.TransactionReceipt(context.Background(), tx.Hash())
 			if err != nil {
-				log.Warn("Error fetching receipt for tx ", tx.Hash(), ": ", err, " Retrying in 15 seconds...")
-				time.Sleep(15 * time.Second)
-				continue
+				return errors.New("Error fetching receipt for tx " + tx.Hash().String() + ": " + err.Error())
 			}
-			break
+			return nil
+		}, GetRetryOpts(opts)...)
+
+		if err != nil {
+			return nil, nil, errors.New("Could not fetch receipt for tx " + tx.Hash().String() + ": " + err.Error())
 		}
 		receipts = append(receipts, receipt)
 	}
@@ -263,16 +271,26 @@ func (f *Onchain) GetExecHeaderAndReceipts(blockNumber *big.Int, rawTxs []bellat
 
 // TODO: Wondering if we can be sure that the smart contract can differentiate
 // between subscriptions and donations.
-func (o *Onchain) GetDonationEvents(blockNumber uint64) []Donation {
-	// Not the most effective way, but we just need to advance one by one.
+func (o *Onchain) GetDonationEvents(blockNumber uint64, opts ...retry.Option) ([]Donation, error) {
 	startBlock := uint64(blockNumber)
 	endBlock := uint64(blockNumber)
 
+	// Not the most effective way, but we just need to advance one by one.
 	filterOpts := &bind.FilterOpts{Context: context.Background(), Start: startBlock, End: &endBlock}
 
-	itr, err := o.Contract.FilterDonation(filterOpts)
+	var err error
+	var itr *contract.ContractDonationIterator
+
+	err = retry.Do(func() error {
+		itr, err = o.Contract.FilterDonation(filterOpts)
+		if err != nil {
+			return errors.New("Error filtering donations for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
+		}
+		return nil
+	}, GetRetryOpts(opts)...)
+
 	if err != nil {
-		log.Fatal("coult not filter donations for block: ", blockNumber, " err: ", err)
+		return nil, errors.New("Could not filter donations for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
 	}
 
 	// Loop over all found events
@@ -286,6 +304,7 @@ func (o *Onchain) GetDonationEvents(blockNumber uint64) []Donation {
 			"Type":        "Donation",
 			"TxHash":      event.Raw.TxHash.Hex()[0:8],
 		}).Info("New Reward")
+
 		donations = append(donations, Donation{
 			AmountWei: event.DonationAmount,
 			Block:     blockNumber,
@@ -296,7 +315,7 @@ func (o *Onchain) GetDonationEvents(blockNumber uint64) []Donation {
 	if err != nil {
 		log.Fatal("could not close iterator for new donation events", err)
 	}
-	return donations
+	return donations, nil
 }
 
 func (o *Onchain) GetContractMerkleRoot(opts ...retry.Option) (string, error) {
@@ -321,16 +340,24 @@ func (o *Onchain) GetContractMerkleRoot(opts ...retry.Option) (string, error) {
 	return rewardsRootStr, nil
 }
 
-func (o *Onchain) GetEthBalance(address string) *big.Int {
+func (o *Onchain) GetEthBalance(address string, opts ...retry.Option) (*big.Int, error) {
 	account := common.HexToAddress(address)
-	balanceWei, err := o.ExecutionClient.BalanceAt(context.Background(), account, nil)
+	var err error
+	var balanceWei *big.Int
 
-	// Allow some retries before failing
+	err = retry.Do(func() error {
+		balanceWei, err = o.ExecutionClient.BalanceAt(context.Background(), account, nil)
+		if err != nil {
+			return errors.New("could not get balance for address " + address + ": " + err.Error())
+		}
+		return nil
+	}, GetRetryOpts(opts)...)
+
 	if err != nil {
-		log.Fatal(err)
+		return nil, errors.New("could not get balance for address " + address + ": " + err.Error())
 	}
 
-	return balanceWei
+	return balanceWei, nil
 }
 
 func (o *Onchain) UpdateContractMerkleRoot(newMerkleRoot string) string {

--- a/oracle/onchain_test.go
+++ b/oracle/onchain_test.go
@@ -52,7 +52,7 @@ func Test_GetBellatrixBlockAtSlot(t *testing.T) {
 	slotToFetch := uint64(5214321)
 
 	// Get block
-	signedBeaconBlock, err := onchain.GetBlockAtSlot(slotToFetch)
+	signedBeaconBlock, err := onchain.GetConsensusBlockAtSlot(slotToFetch)
 	require.NoError(t, err)
 
 	// Cast to our custom extended block with extra methods

--- a/oracle/onchain_test.go
+++ b/oracle/onchain_test.go
@@ -26,9 +26,10 @@ func Test_FetchFromExecution(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchainTest = NewOnchain(cfgOnchain)
+	onChain, err := NewOnchain(cfgOnchain)
+	require.NoError(t, err)
 	account := common.HexToAddress("0xf573d99385c05c23b24ed33de616ad16a43a0919")
-	balance, err := onchainTest.ExecutionClient.BalanceAt(context.Background(), account, nil)
+	balance, err := onChain.ExecutionClient.BalanceAt(context.Background(), account, nil)
 	require.NoError(t, err)
 	expectedValue, ok := new(big.Int).SetString("25893180161173005034", 10)
 	require.True(t, ok)
@@ -43,7 +44,8 @@ func Test_GetBellatrixBlockAtSlot(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchain = NewOnchain(cfgOnchain)
+	onchain, err := NewOnchain(cfgOnchain)
+	require.NoError(t, err)
 	folder := "../mock"
 	blockType := "capella"
 	network := "goerli"

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -49,7 +49,7 @@ func (or *Oracle) GetBlockIfAny(slot uint64) (uint64, string, bool, *VersionedSi
 	valIndexDuty := uint64(slotDuty.ValidatorIndex)
 	valPublicKey := "0x" + hex.EncodeToString(slotDuty.PubKey[:])
 
-	proposedBlock, err := or.onchain.GetBlockAtSlot(slot)
+	proposedBlock, err := or.onchain.GetConsensusBlockAtSlot(slot)
 	if err != nil {
 		log.Fatal("could not get block at slot:", err)
 	}
@@ -148,7 +148,10 @@ func (or *Oracle) AdvanceStateToNextSlot() (uint64, error) {
 
 		// TODO: Confirm that the event only emits donations and is not mixed with other events
 		// Get donations using emitted events. Iterate them and share
-		blockDonations := or.onchain.GetDonationEvents(blockNumber)
+		blockDonations, err := or.onchain.GetDonationEvents(blockNumber)
+		if err != nil {
+			log.Fatal(err)
+		}
 		for _, donation := range blockDonations {
 			or.State.AddDonation(donation)
 			or.State.IncreaseAllPendingRewards(donation.AmountWei)

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -14,7 +14,8 @@ func Test_EndToEnd_VanilaReward(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchain = NewOnchain(cfg)
+	onchain, err := NewOnchain(cfg)
+	require.NoError(t, err)
 	oracle := NewOracle(&config.Config{
 		PoolAddress:           "0xffee087852cb4898e6c3532e776e68bc68b1143b",
 		CheckPointSizeInSlots: 5,
@@ -36,7 +37,8 @@ func Test_EndToEnd_MevReward(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchain = NewOnchain(cfg)
+	onchain, err := NewOnchain(cfg)
+	require.NoError(t, err)
 	oracle := NewOracle(&config.Config{
 		PoolAddress:           "0x4675c7e5baafbffbca748158becba61ef3b0a263",
 		CheckPointSizeInSlots: 5,
@@ -56,7 +58,8 @@ func Test_EndToEnd_NoSubscriptions(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchain = NewOnchain(cfg)
+	onchain, err := NewOnchain(cfg)
+	require.NoError(t, err)
 	oracle := NewOracle(&config.Config{
 		PoolAddress:           "0x4675c7e5baafbffbca748158becba61ef3b0a263",
 		CheckPointSizeInSlots: 100,
@@ -108,7 +111,8 @@ func Test_IsValidatorSubscribed(t *testing.T) {
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	var onchain = NewOnchain(cfg)
+	onchain, err := NewOnchain(cfg)
+	require.NoError(t, err)
 	_ = onchain
 	//oracle := NewOracle(&config.Config{}, onchain)
 	//var subscriptions = Subscriptions{


### PR DESCRIPTION
* Most of the interactions with the execution and consensus client were only tried once, and panic if failing.
* This PR introduces a configurable retry logic, where up to `n` times the requests is retried (with some configurable logic and backoff)