### PR TITLE
Add memory vs onchain api endpoints + refactors

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -4,11 +4,20 @@ This document contains some non-exhaustive documentation for the oracle api, wit
 
 
 // TODO: modify this to validatorindex=xxx
+Outdated!
 
 curl 157.90.93.245:7300/status
+
 curl 157.90.93.245:7300/depositadddress/408070
+
 curl 157.90.93.245:7300/proof/0xa111B576408B1CcDacA3eF26f22f082C49bcaa55
+
 curl 157.90.93.245:7300/validatoronchainstate/408070
+
 curl 157.90.93.245:7300/donations
+
 curl 157.90.93.245:7300/poolstatistics
+
 curl 157.90.93.245:7300/registeredrelays/0xb1ce83f50ba296bdfedba0e4a42a65f8cee1bdeb2ba78aaa61b452141684930406412bbef6c0f65b4121f8fc82dbb6ba
+
+

--- a/api/api.go
+++ b/api/api.go
@@ -130,9 +130,9 @@ type httpOkValidatorState struct {
 	DepositAddress        string   `json:"deposit_address"`
 	ValidatorIndex        uint64   `json:"validator_index"`
 	ValidatorKey          string   `json:"validator_key"`
-	//ProposedBlocksSlots   []BlockState
-	//MissedBlocksSlots     []BlockState
-	//WrongFeeBlocksSlots   []BlockState
+	//ValidatorProposedBlocks   []BlockState
+	//ValidatorMissedBlocks     []BlockState
+	//ValidatorWrongFeeBlocks   []BlockState
 
 	// TODO: Include ClaimedSoFar from the smart contract for reconciliation
 }

--- a/api/api.go
+++ b/api/api.go
@@ -22,6 +22,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Note that the api has no paging, so it is not suitable for large queries, but
+// it should be able to scale to a few thousand subscribed validators without any problem
+
 // These are the retry options when an api call involves external call to the beacon node
 // or execution client. The idea is to try once, and fail fast.
 // Use this for all onchain calls, otherwise defaultRetryOpts will be aplied
@@ -31,36 +34,31 @@ var apiRetryOpts = []retry.Option{
 
 const (
 	// Available endpoints
-
 	pathStatus                = "/status"
-	pathLatestCheckpoint      = "/latestcheckpoint"
-	pathLatestMerkleProof     = "/proof/{depositaddress}"
-	pathLatestMerkleRoot      = "/merkleroot"
-	pathDepositAddressByIndex = "/depositadddress/{valindex}"
-	pathPoolStatistics        = "/poolstatistics"
-	pathDonations             = "/donations"
 	pathValidatorRelayers     = "/registeredrelays/{valpubkey}"
+	pathDepositAddressByIndex = "/depositaddress/{valindex}"
 
-	// TODO: better valindex=xxx
+	// Memory endpoints: what the oracle knows
+	pathMemoryValidators          = "/memory/validators"
+	pathMemoryValidatorByIndex    = "/memory/validator/{valindex}"
+	pathMemoryValidatorsByDeposit = "/memory/validators/{depositaddress}"
+	pathMemoryFeesInfo            = "/memory/feesinfo"
+	pathMemorySubscriptions       = "/memory/subscriptions"   // TODO
+	pathMemoryUnsubscriptions     = "/memory/unsubscriptions" // TODO
+	pathMemoryProposedBlocks      = "/memory/proposedblocks"
+	pathMemoryMissedBlocks        = "/memory/missedblocks"
+	pathMemoryWrongFeeBlocks      = "/memory/wrongfeeblocks"
+	pathMemoryDonations           = "/memory/donations"
+	pathMemoryPoolStatistics      = "/memory/statistics"
 
-	// TODO: Perhaps rethink this a bit. There are two types of state:
-	// Have two similar endpoints
-	// -/memory/ (what is stored in memory aka, oracle knows)
-	// -/onchain/ (what is submitted to the contract)
-	// - The state that is already submitted onchain
-	pathValidatorOnchainStateByIndex  = "/validatoronchainstate/{valindex}"
-	pathValidatorOffchainStateByIndex = "/validatoroffchainstate/{valindex}"
-
-	// TODO: Get all validators for a deposit address
-	// TODO: add endpoint with subscriptions and unsubscriptions events for trazability
-
-	pathValidatorStateByDeposit = ""
-
-	// TODO: Fees generated (list accumulated of fee account)
-
-	// TODO:
-	// proof
-	// missed block, proposed blocks ok, etc.
+	// Onchain endpoints: what is submitted to the contract
+	pathOnchainValidators          = "/onchain/validators"                  // TODO
+	pathOnchainValidatorByIndex    = "/onchain/validator/{valindex}"        // TODO
+	pathOnchainValidatorsByDeposit = "/onchain/validators/{depositaddress}" // TODO
+	pathOnchainFeesInfo            = "/onchain/proof/fees"                  // TODO
+	pathOnchainMerkleRoot          = "/onchain/merkleroot"                  // TODO
+	pathOnchainMerkleProof         = "/onchain/proof/{depositaddress}"      // TODO
+	pathOnchainLatestCheckpoint    = "/onchain/latestcheckpoint"            // TODO
 )
 
 type httpErrorResp struct {
@@ -78,9 +76,10 @@ type httpOkStatus struct {
 	DepositContact            string `json:"depositcontract"`
 }
 
-type httpOkLatestCheckpoint struct {
-	MerkleRoot     string `json:"merkleroot"`
-	CheckpointSlot uint64 `json:"checkpointslot"`
+type httpOkRelayersState struct {
+	Registered           bool     `json:"registered"`
+	RegisteredRelayers   []string `json:"registered_relayers"`
+	UnRegisteredRelayers []string `json:"unregistered_relayers"`
 }
 
 type httpOkDepositAddress struct {
@@ -89,18 +88,16 @@ type httpOkDepositAddress struct {
 	ValidatorAddress string `json:"validator_address"`
 }
 
+type httpOkLatestCheckpoint struct {
+	MerkleRoot     string `json:"merkleroot"`
+	CheckpointSlot uint64 `json:"checkpointslot"`
+}
+
 type httpOkMerkleRoot struct {
 	MerkleRoot string `json:"merkle_root"`
 }
 
-type httpOkDonations struct {
-	DonationAmountWei []*big.Int `json:"donation_amount_wei"`
-	DonationBlock     []uint64   `json:"donation_block"`
-	DonationTxHash    []string   `json:"donation_tx_hash"`
-}
-
-type httpOkPoolStatatistics struct {
-	OnchainMerkleRoot  string `json:"onchain_merkle_root"`
+type httpOkMemoryStatistics struct {
 	TotalSubscribed    uint64 `json:"total_subscribed_validators"`
 	TotalActive        uint64 `json:"total_active_validators"`
 	TotalYellowCard    uint64 `json:"total_yellowcard_validators"`
@@ -108,13 +105,14 @@ type httpOkPoolStatatistics struct {
 	TotalBanned        uint64 `json:"total_banned_validators"`
 	TotalNotSubscribed uint64 `json:"total_notsubscribed_validators"`
 
-	LatestCheckpointSlot uint64 `json:"latest_checkpoint_slot"`
-	NextCheckpointSlot   uint64 `json:"next_checkpoint_slot"`
+	LatestCheckpointSlot       uint64   `json:"latest_checkpoint_slot"`
+	NextCheckpointSlot         uint64   `json:"next_checkpoint_slot"`
+	TotalAccumulatedRewardsWei *big.Int `json:"total_accumulated_rewards_wei"`
+	TotalPendingRewaradsWei    *big.Int `json:"total_pending_rewards_wei"`
 
-	// TODO: Clarify if wei or gwei and add to name
-	TotalAccumulatedRewards *big.Int `json:"total_accumulated_rewards"`
-	// TODO: Clarify if wei or gwei and add to name
-	TotalPendingRewarads *big.Int `json:"total_pending_rewards"`
+	TotalRewardsSentWei *big.Int `json:"total_rewards_sent_wei"`
+	TotalDonationsWei   *big.Int `json:"total_donations_wei"`
+	AvgBlockRewardWei   *big.Int `json:"avg_block_reward_wei"`
 
 	// TODO: Split Proposed in Vanila/Mev
 	//TotalVanilaBlocks   uint64
@@ -125,11 +123,10 @@ type httpOkPoolStatatistics struct {
 }
 
 type httpOkValidatorState struct {
-	StatusType            string   `json:"statustype"` // TODO: populate
-	ValidatorStatus       string   `json:"validatorstatus"`
+	ValidatorStatus       string   `json:"status"`
 	AccumulatedRewardsWei *big.Int `json:"accumulated_rewards_wei"`
 	PendingRewardsWei     *big.Int `json:"pending_rewards_wei"`
-	CollateralWei         *big.Int `json:"collateral_rewards_wei"` // TODO: unsure if its we or gwei
+	CollateralWei         *big.Int `json:"collateral_rewards_wei"`
 	DepositAddress        string   `json:"deposit_address"`
 	ValidatorIndex        uint64   `json:"validator_index"`
 	ValidatorKey          string   `json:"validator_key"`
@@ -147,12 +144,6 @@ type httpOkProofs struct {
 	CheckpointSlot         uint64   `json:"checkpoint_slot"`
 	Proofs                 []string `json:"merkle_proofs"`
 	RegisteredValidators   []uint64 `json:"registered_validators"`
-}
-
-type httpOkRelayersState struct {
-	Registered           bool     `json:"registered"`
-	RegisteredRelayers   []string `json:"registered_relayers"`
-	UnRegisteredRelayers []string `json:"unregistered_relayers"`
 }
 
 type ApiService struct {
@@ -205,17 +196,28 @@ func (m *ApiService) getRouter() http.Handler {
 
 	// Map endpoints and their handlers
 	r.HandleFunc("/", m.handleRoot).Methods(http.MethodGet)
-	r.HandleFunc(pathStatus, m.handleStatus).Methods(http.MethodGet)
-	r.HandleFunc(pathLatestMerkleProof, m.handleLatestMerkleProof)
-	r.HandleFunc(pathLatestMerkleRoot, m.handleLatestMerkleRoot)
-	r.HandleFunc(pathLatestCheckpoint, m.handleLatestCheckpoint)
-	r.HandleFunc(pathDepositAddressByIndex, m.handleDepositAddressByIndex)
-	r.HandleFunc(pathValidatorRelayers, m.handleValidatorRelayers).Methods(http.MethodGet)
 
-	r.HandleFunc(pathValidatorOnchainStateByIndex, m.handleValidatorOnchainStateByIndex)
-	r.HandleFunc(pathValidatorOffchainStateByIndex, m.handleValidatorOffchainStateByIndex)
-	r.HandleFunc(pathPoolStatistics, m.handlePoolStatistics)
-	r.HandleFunc(pathDonations, m.handleDonations)
+	r.HandleFunc(pathStatus, m.handleStatus).Methods(http.MethodGet)
+	r.HandleFunc(pathValidatorRelayers, m.handleValidatorRelayers).Methods(http.MethodGet)
+	r.HandleFunc(pathDepositAddressByIndex, m.handleDepositAddressByIndex).Methods(http.MethodGet)
+
+	r.HandleFunc(pathMemoryValidators, m.handleMemoryValidators).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryValidatorByIndex, m.handleMemoryValidatorInfo).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryValidatorsByDeposit, m.handleMemoryValidatorsByDeposit).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryFeesInfo, m.handleMemoryFeesInfo).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryPoolStatistics, m.handleMemoryStatistics).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryProposedBlocks, m.handleMemoryProposedBlocks).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryMissedBlocks, m.handleMemoryMissedBlocks).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryWrongFeeBlocks, m.handleMemoryWrongFeeBlocks).Methods(http.MethodGet)
+	r.HandleFunc(pathMemoryDonations, m.handleMemoryDonations).Methods(http.MethodGet)
+
+	//r.HandleFunc(pathLatestMerkleProof, m.handleLatestMerkleProof)
+	//r.HandleFunc(pathLatestMerkleRoot, m.handleLatestMerkleRoot)
+	//r.HandleFunc(pathLatestCheckpoint, m.handleLatestCheckpoint)
+
+	//r.HandleFunc(pathValidatorOnchainStateByIndex, m.handleValidatorOnchainStateByIndex)
+	//r.HandleFunc(pathValidatorOffchainStateByIndex, m.handleValidatorOffchainStateByIndex)
+	//r.HandleFunc(pathDonations, m.handleDonations)
 
 	//r.Use(mux.CORSMethodMiddleware(r))
 
@@ -254,17 +256,7 @@ func (m *ApiService) handleRoot(w http.ResponseWriter, req *http.Request) {
 	m.respondOK(w, "see api doc for available endpoints")
 }
 
-func (m *ApiService) handlePoolStatistics(w http.ResponseWriter, req *http.Request) {
-	// TODO: Compare they are equal. They will be unless the oracle is restarted and
-	// has to catch up
-	//oracleMerkleRoot := "0x" + m.OracleState.LatestCommitedState.MerkleRoot
-
-	contractMerkleRoot, err := m.Onchain.GetContractMerkleRoot(apiRetryOpts...)
-	if err != nil {
-		m.respondError(w, http.StatusBadRequest, "could not get latest merkle root from chain")
-		return
-	}
-
+func (m *ApiService) handleMemoryStatistics(w http.ResponseWriter, req *http.Request) {
 	totalSubscribed := uint64(0)
 	totalActive := uint64(0)
 	totalYellowCard := uint64(0)
@@ -275,14 +267,11 @@ func (m *ApiService) handlePoolStatistics(w http.ResponseWriter, req *http.Reque
 	totalAccumulatedRewards := big.NewInt(0)
 	totalPendingRewards := big.NewInt(0)
 
+	// TODO: Would be nice to divice en MEV and non-MEV blocks
 	//totalVanilaBlocks := 0
 	//totalMevBlocks := 0
-	totalProposedBlocks := uint64(0)
-	totalMissedBlocks := uint64(0)
-	totalWrongFeeBlocks := uint64(0)
 
-	// Unsure if its better to return the latest commited or the oracle state
-	for _, validator := range m.OracleState.LatestCommitedState.Validators {
+	for _, validator := range m.OracleState.Validators {
 		if validator.ValidatorStatus == oracle.Active {
 			totalActive++
 		} else if validator.ValidatorStatus == oracle.YellowCard {
@@ -296,32 +285,44 @@ func (m *ApiService) handlePoolStatistics(w http.ResponseWriter, req *http.Reque
 		}
 		totalAccumulatedRewards.Add(totalAccumulatedRewards, validator.AccumulatedRewardsWei)
 		totalPendingRewards.Add(totalPendingRewards, validator.PendingRewardsWei)
-
-		totalProposedBlocks += uint64(len(validator.ProposedBlocksSlots))
-		totalMissedBlocks += uint64(len(validator.MissedBlocksSlots))
-		totalWrongFeeBlocks += uint64(len(validator.WrongFeeBlocksSlots))
 	}
 
 	totalSubscribed = totalActive + totalYellowCard + totalRedCard
 
-	m.respondOK(w, httpOkPoolStatatistics{
-		OnchainMerkleRoot:  contractMerkleRoot,
-		TotalSubscribed:    totalSubscribed,
-		TotalActive:        totalActive,
-		TotalYellowCard:    totalYellowCard,
-		TotalRedCard:       totalRedCard,
-		TotalBanned:        totalBanned,
-		TotalNotSubscribed: totalNotSubscribed,
+	totalRewardsSentWei := big.NewInt(0)
+	for _, block := range m.OracleState.ProposedBlocks {
+		totalRewardsSentWei.Add(totalRewardsSentWei, block.Reward)
+	}
+	totalDonationsWei := big.NewInt(0)
+	for _, donation := range m.OracleState.Donations {
+		totalDonationsWei.Add(totalDonationsWei, donation.AmountWei)
+	}
 
-		LatestCheckpointSlot: m.OracleState.LatestSlot,
-		NextCheckpointSlot:   m.OracleState.LatestSlot + m.Onchain.Cfg.CheckPointSizeInSlots,
+	totalProposedBlocks := uint64(len(m.OracleState.ProposedBlocks))
+	avgBlockRewardWei := big.NewInt(0)
 
-		TotalAccumulatedRewards: totalAccumulatedRewards,
-		TotalPendingRewarads:    totalPendingRewards,
+	// Avoid division by zero
+	if totalProposedBlocks != 0 {
+		avgBlockRewardWei = big.NewInt(0).Div(totalRewardsSentWei, big.NewInt(0).SetUint64(uint64(len(m.OracleState.ProposedBlocks))))
+	}
 
-		TotalProposedBlocks: totalProposedBlocks,
-		TotalMissedBlocks:   totalMissedBlocks,
-		TotalWrongFeeBlocks: totalWrongFeeBlocks,
+	m.respondOK(w, httpOkMemoryStatistics{
+		TotalSubscribed:            totalSubscribed,
+		TotalActive:                totalActive,
+		TotalYellowCard:            totalYellowCard,
+		TotalRedCard:               totalRedCard,
+		TotalBanned:                totalBanned,
+		TotalNotSubscribed:         totalNotSubscribed,
+		LatestCheckpointSlot:       m.OracleState.LatestSlot,                                       // This is wrong. TODO: convert date
+		NextCheckpointSlot:         m.OracleState.LatestSlot + m.Onchain.Cfg.CheckPointSizeInSlots, // TODO: Also wrong. convert to date
+		TotalAccumulatedRewardsWei: totalAccumulatedRewards,
+		TotalPendingRewaradsWei:    totalPendingRewards,
+		TotalRewardsSentWei:        totalRewardsSentWei,
+		TotalDonationsWei:          totalDonationsWei,
+		AvgBlockRewardWei:          avgBlockRewardWei,
+		TotalProposedBlocks:        totalProposedBlocks,
+		TotalMissedBlocks:          uint64(len(m.OracleState.MissedBlocks)),
+		TotalWrongFeeBlocks:        uint64(len(m.OracleState.WrongFeeBlocks)),
 	})
 }
 
@@ -380,6 +381,87 @@ func (m *ApiService) handleStatus(w http.ResponseWriter, req *http.Request) {
 	m.respondOK(w, status)
 }
 
+func (m *ApiService) handleMemoryValidators(w http.ResponseWriter, req *http.Request) {
+	// Perhaps a bit dangerours to access this directly without getters.
+	m.respondOK(w, m.OracleState.Validators)
+}
+
+func (m *ApiService) handleMemoryValidatorInfo(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	valIndexStr := vars["valindex"]
+	valIndex, ok := IsValidIndex(valIndexStr)
+
+	if !ok {
+		m.respondError(w, http.StatusBadRequest, "invalid validator index: "+valIndexStr)
+		return
+	}
+
+	validator, found := m.OracleState.Validators[valIndex]
+	if !found {
+		m.respondError(w, http.StatusBadRequest, fmt.Sprint("could not find validator with index: ", valIndex))
+		return
+	}
+
+	m.respondOK(w, validator)
+}
+
+func (m *ApiService) handleMemoryValidatorsByDeposit(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	depositAddress := vars["depositaddress"]
+
+	if !IsValidAddress(depositAddress) {
+		m.respondError(w, http.StatusBadRequest, "invalid depositAddress: "+depositAddress)
+		return
+	}
+
+	// Use always lowercase
+	depositAddress = strings.ToLower(depositAddress)
+	validatorsByDeposit := make([]*oracle.ValidatorInfo, 0)
+
+	// Get the validators that have the requested deposit address
+	for _, validator := range m.OracleState.Validators {
+		if validator.DepositAddress == depositAddress {
+			validatorsByDeposit = append(validatorsByDeposit, validator)
+		}
+	}
+
+	m.respondOK(w, validatorsByDeposit)
+}
+
+func (m *ApiService) handleMemoryFeesInfo(w http.ResponseWriter, req *http.Request) {
+	type httpOkMemoryFeesInfo struct {
+		PoolFeesPercent     int      `json:"pool_fee_percent"`
+		PoolFeesAddress     string   `json:"pool_fee_address"`
+		PoolAccumulatedFees *big.Int `json:"pool_accumulated_fees"`
+	}
+
+	m.respondOK(w, httpOkMemoryFeesInfo{
+		PoolFeesPercent:     m.OracleState.PoolFeesPercent,
+		PoolFeesAddress:     m.OracleState.PoolFeesAddress,
+		PoolAccumulatedFees: m.OracleState.PoolAccumulatedFees,
+	})
+}
+
+func (m *ApiService) handleMemoryProposedBlocks(w http.ResponseWriter, req *http.Request) {
+	// TODO: Use getter, since its safer and dont make this fields public
+	m.respondOK(w, m.OracleState.ProposedBlocks)
+}
+
+func (m *ApiService) handleMemoryMissedBlocks(w http.ResponseWriter, req *http.Request) {
+	// TODO: Use getter, since its safer and dont make this fields public
+	m.respondOK(w, m.OracleState.MissedBlocks)
+}
+
+func (m *ApiService) handleMemoryWrongFeeBlocks(w http.ResponseWriter, req *http.Request) {
+	// TODO: Use getter, since its safer and dont make this fields public
+	m.respondOK(w, m.OracleState.WrongFeeBlocks)
+}
+
+func (m *ApiService) handleMemoryDonations(w http.ResponseWriter, req *http.Request) {
+	// TODO: Use getter, since its safer and dont make this fields public
+	m.respondOK(w, m.OracleState.Donations)
+}
+
 func (m *ApiService) handleLatestMerkleProof(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	depositAddress := vars["depositaddress"]
@@ -436,16 +518,6 @@ func (m *ApiService) handleLatestMerkleRoot(w http.ResponseWriter, req *http.Req
 	m.respondOK(w, httpOkMerkleRoot{
 		MerkleRoot: contractMerkleRoot,
 	})
-}
-
-func (m *ApiService) handleDonations(w http.ResponseWriter, req *http.Request) {
-	httpOkDonations := httpOkDonations{}
-	for _, donation := range m.OracleState.Donations {
-		httpOkDonations.DonationAmountWei = append(httpOkDonations.DonationAmountWei, donation.AmountWei)
-		httpOkDonations.DonationBlock = append(httpOkDonations.DonationBlock, donation.Block)
-		httpOkDonations.DonationTxHash = append(httpOkDonations.DonationTxHash, donation.TxHash)
-	}
-	m.respondOK(w, httpOkDonations)
 }
 
 func (m *ApiService) handleDepositAddressByIndex(w http.ResponseWriter, req *http.Request) {
@@ -510,34 +582,6 @@ func (m *ApiService) handleValidatorOnchainStateByIndex(w http.ResponseWriter, r
 	})
 }
 
-func (m *ApiService) handleValidatorOffchainStateByIndex(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	valIndex, err := strconv.ParseUint(vars["valindex"], 10, 64)
-	if err != nil {
-		m.respondError(w, http.StatusInternalServerError, "could not parse valIndex: "+err.Error())
-		return
-	}
-
-	// We look into the local state. This can contain data that the oracle tracks but that its not
-	// yet published onchain
-	valState, found := m.OracleState.Validators[uint64(valIndex)]
-	if !found {
-		m.respondError(w, http.StatusInternalServerError, fmt.Sprintf("validator index not tracked in the oracle: %d", valIndex))
-		return
-	}
-	m.respondOK(w, httpOkValidatorState{
-		ValidatorStatus:       oracle.ValidatorStateToString(valState.ValidatorStatus),
-		AccumulatedRewardsWei: valState.AccumulatedRewardsWei,
-		PendingRewardsWei:     valState.PendingRewardsWei,
-		CollateralWei:         valState.CollateralWei,
-		DepositAddress:        valState.DepositAddress,
-		ValidatorIndex:        valState.ValidatorIndex,
-		ValidatorKey:          valState.ValidatorKey,
-		// TODO: Missing blocks fields
-	})
-}
-
 func (m *ApiService) handleValidatorRelayers(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	valPubKey := vars["valpubkey"]
@@ -582,6 +626,15 @@ func (m *ApiService) handleValidatorRelayers(w http.ResponseWriter, req *http.Re
 		RegisteredRelayers:   registeredRelays,
 		UnRegisteredRelayers: unregisteredRelays,
 	})
+}
+
+func IsValidIndex(v string) (uint64, bool) {
+	//re := regexp.MustCompile("^[0-9]+$")
+	val, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return val, true
 }
 
 func IsValidAddress(v string) bool {

--- a/oracle/block.go
+++ b/oracle/block.go
@@ -92,12 +92,12 @@ func (b *VersionedSignedBeaconBlock) MevRewardInWei(poolAddress string) (*big.In
 // need to reconstruct the tip from the txs.
 func (b *VersionedSignedBeaconBlock) GetSentRewardAndType(
 	poolAddress string,
-	onchain Onchain) (*big.Int, bool, int, error) {
+	onchain Onchain) (*big.Int, bool, RewardType, error) {
 
 	var reward *big.Int = big.NewInt(0)
 	err := *new(error)
 	var numTxs int = 0
-	var txType int = -1
+	var txType RewardType = UnknownRewardType
 	var wasRewardSent bool = false
 
 	if len(b.GetFeeRecipient()) != len(poolAddress) {

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -175,7 +175,17 @@ func (p *OracleState) SaveStateToFile() {
 }
 
 func ReadStateFromFile() (*OracleState, error) {
-	state := OracleState{}
+	// Init all fields in case any was stored empty in the file
+	state := OracleState{
+		Validators:          make(map[uint64]*ValidatorInfo, 0),
+		PoolAccumulatedFees: big.NewInt(0),
+		Subscriptions:       make([]Subscription, 0),
+		Unsubscriptions:     make([]Unsubscription, 0),
+		Donations:           make([]Donation, 0),
+		ProposedBlocks:      make([]Block, 0),
+		MissedBlocks:        make([]Block, 0),
+		WrongFeeBlocks:      make([]Block, 0),
+	}
 
 	file, err := os.Open(StateFileName)
 

--- a/oracle/oraclestate_test.go
+++ b/oracle/oraclestate_test.go
@@ -224,7 +224,23 @@ func Test_StateMachine(t *testing.T) {
 		require.Equal(t, testState.End, state.Validators[valIndex2].ValidatorStatus)
 	}
 }
-func Test_SaveLoadFromToFile(t *testing.T) {
+
+func Test_SaveLoadFromToFile_EmptyState(t *testing.T) {
+	state := NewOracleState(&config.Config{
+		PoolAddress:     "0x0000000000000000000000000000000000000000",
+		PoolFeesAddress: "0x1000000000000000000000000000000000000000",
+		Network:         "mainnet",
+	})
+
+	StateFileName = "test_state.gob"
+	defer os.Remove(StateFileName)
+	state.SaveStateToFile()
+
+	recovered, err := ReadStateFromFile()
+	require.NoError(t, err)
+	require.Equal(t, state, recovered)
+}
+func Test_SaveLoadFromToFile_PopulatedState(t *testing.T) {
 
 	state := NewOracleState(&config.Config{
 		PoolAddress:     "0x0000000000000000000000000000000000000000",

--- a/oracle/oraclestate_test.go
+++ b/oracle/oraclestate_test.go
@@ -183,9 +183,9 @@ func Test_StateMachine(t *testing.T) {
 	valIndex2 := uint64(2000)
 
 	type stateTest struct {
-		From  int
-		Event int
-		End   int
+		From  ValidatorStatus
+		Event Event
+		End   ValidatorStatus
 	}
 
 	stateMachineTestVector := []stateTest{

--- a/oracle/oraclestate_test.go
+++ b/oracle/oraclestate_test.go
@@ -248,7 +248,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 		DepositAddress:        "0xa000000000000000000000000000000000000000",
 		ValidatorIndex:        10,
 		ValidatorKey:          "0xc", // TODO: Fix this, should be uint64
-		ProposedBlocksSlots: []Block{
+		ValidatorProposedBlocks: []Block{
 			Block{
 				Reward:     big.NewInt(1000),
 				RewardType: VanilaBlock,
@@ -262,7 +262,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 				RewardType: MevBlock,
 				Slot:       6000,
 			}},
-		MissedBlocksSlots: []Block{Block{
+		ValidatorMissedBlocks: []Block{Block{
 			Reward:     big.NewInt(1000),
 			RewardType: VanilaBlock,
 			Slot:       500,
@@ -271,7 +271,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 			RewardType: VanilaBlock,
 			Slot:       12000,
 		}},
-		WrongFeeBlocksSlots: []Block{Block{
+		ValidatorWrongFeeBlocks: []Block{Block{
 			Reward:     big.NewInt(1000),
 			RewardType: VanilaBlock,
 			Slot:       500,
@@ -290,7 +290,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 		DepositAddress:        "0xa000000000000000000000000000000000000000",
 		ValidatorIndex:        20,
 		ValidatorKey:          "0xc",
-		ProposedBlocksSlots: []Block{
+		ValidatorProposedBlocks: []Block{
 			Block{
 				Reward:     big.NewInt(1000),
 				RewardType: VanilaBlock,
@@ -304,7 +304,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 				RewardType: MevBlock,
 				Slot:       6000,
 			}},
-		MissedBlocksSlots: []Block{Block{
+		ValidatorMissedBlocks: []Block{Block{
 			Reward:     big.NewInt(33000),
 			RewardType: VanilaBlock,
 			Slot:       800,
@@ -313,7 +313,7 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 			RewardType: VanilaBlock,
 			Slot:       15000,
 		}},
-		WrongFeeBlocksSlots: []Block{Block{
+		ValidatorWrongFeeBlocks: []Block{Block{
 			Reward:     big.NewInt(14000),
 			RewardType: VanilaBlock,
 			Slot:       700,
@@ -333,12 +333,12 @@ func Test_SaveLoadFromToFile(t *testing.T) {
 		ValidatorIndex:        30,
 		ValidatorKey:          "0xc",
 		// Empty Proposed blocks
-		MissedBlocksSlots: []Block{Block{
+		ValidatorMissedBlocks: []Block{Block{
 			Reward:     big.NewInt(303000),
 			RewardType: VanilaBlock,
 			Slot:       12200,
 		}},
-		WrongFeeBlocksSlots: []Block{Block{
+		ValidatorWrongFeeBlocks: []Block{Block{
 			Reward:     big.NewInt(15000),
 			RewardType: VanilaBlock,
 			Slot:       800,


### PR DESCRIPTION
Split the api endpoints into:
* `memory`: what the oracle know 
* `onchain`: whats stored onchain (in the merkle root)