### PR TITLE
Add retry flag + retry in postgres

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,8 +25,8 @@ import (
 // Note that the api has no paging, so it is not suitable for large queries, but
 // it should be able to scale to a few thousand subscribed validators without any problem
 
-// These are the retry options when an api call involves external call to the beacon node
-// or execution client. The idea is to try once, and fail fast.
+// Important: These are the retry options when an api call involves external call to
+// the beacon node or execution client. The idea is to try once, and fail fast.
 // Use this for all onchain calls, otherwise defaultRetryOpts will be aplied
 var apiRetryOpts = []retry.Option{
 	retry.Attempts(1),
@@ -156,7 +156,7 @@ type ApiService struct {
 }
 
 func NewApiService(cfg config.Config, state *oracle.OracleState, onchain *oracle.Onchain) *ApiService {
-	postgres, err := postgres.New(cfg.PostgresEndpoint)
+	postgres, err := postgres.New(cfg.PostgresEndpoint, cfg.NumRetries)
 	if err != nil {
 		// TODO: Return error instead of fatal
 		log.Fatal(err)
@@ -543,17 +543,6 @@ func (m *ApiService) handleDepositAddressByIndex(w http.ResponseWriter, req *htt
 		ValidatorIndex:   valIndex,
 		ValidatorAddress: valPubKeyStr,
 	})
-}
-
-func (m *ApiService) handleLatestCheckpoint(w http.ResponseWriter, req *http.Request) {
-	log.Info("/latestCheckpoint")
-
-	mRoot, slot, err := m.Postgres.GetLatestCheckpoint()
-	if err != nil {
-		m.respondError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	m.respondOK(w, httpOkLatestCheckpoint{mRoot, slot})
 }
 
 func (m *ApiService) handleValidatorOnchainStateByIndex(w http.ResponseWriter, req *http.Request) {

--- a/config/config.go
+++ b/config/config.go
@@ -1,14 +1,11 @@
 package config
 
 import (
-	"bufio"
 	"crypto/ecdsa"
 	"errors"
 	"flag"
 	"math/big"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -28,6 +25,7 @@ type Config struct {
 	PoolFeesPercent       int
 	PoolFeesAddress       string
 	DryRun                bool
+	NumRetries            int
 	CollateralInWei       *big.Int
 }
 
@@ -59,7 +57,13 @@ var TestRelays = []string{
 const MaxUint64 = ^uint64(0)
 
 func NewCliConfig() (*Config, error) {
+	// Optional flags TODO: Test!
 	var version = flag.Bool("version", false, "Prints the release version and exits")
+	var dryRun = flag.Bool("dry-run", false, "If enabled, the pool contract will not be updated")
+	var deployerPrivateKey = flag.String("deployer-private-key", "", "Private key of the deployer account")
+	var numRetries = flag.Int("num-retries", 0, "Number of retries for each interaction (consensus, execution, postgres): 0 infinite")
+
+	// Mandatory flags TODO: Test!
 	var consensusEndpoint = flag.String("consensus-endpoint", "", "Ethereum consensus endpoint")
 	var executionEndpoint = flag.String("execution-endpoint", "", "Ethereum execution endpoint")
 	var network = flag.String("network", "mainnet", "Network to run in: mainnet|goerli")
@@ -67,11 +71,10 @@ func NewCliConfig() (*Config, error) {
 	var deployedSlot = flag.Uint64("deployed-slot", 0, "Deployed slot of the smart contract: slot, not block")
 	var checkPointSizeInSlots = flag.Uint64("checkpoint-size", 0, "Size in slots for each checkpoint, used to generate dumps and update merkle roots")
 	var postgresEndpoint = flag.String("postgres-endpoint", "", "Postgres endpoint")
-	var deployerPrivateKey = flag.String("deployer-private-key", "", "Private key of the deployer account")
 	var poolFeesPercent = flag.Int("pool-fees-percent", -1, "Percent of fees pool-fees-percent takes [0-100]")
 	var poolFeesAddress = flag.String("pool-fees-address", "", "Ethereum account with 0x where pool fees go to")
-	var dryRun = flag.Bool("dry-run", false, "If enabled, the pool contract will not be updated")
 	var ethCollateral = flag.Uint64("collateral-in-wei", MaxUint64, "Amount of collateral in ETH wei")
+
 	flag.Parse()
 
 	if *version {
@@ -162,6 +165,7 @@ func NewCliConfig() (*Config, error) {
 		PoolFeesAddress:       *poolFeesAddress,
 		CollateralInWei:       ethCollateralInWei,
 		DryRun:                *dryRun,
+		NumRetries:            *numRetries,
 	}
 	logConfig(conf)
 	return conf, nil
@@ -182,6 +186,7 @@ func logConfig(cfg *Config) {
 		"PoolFeesAddress":       cfg.PoolFeesAddress,
 		"CollateralInWei":       cfg.CollateralInWei,
 		"DryRun":                cfg.DryRun,
+		"NumRetries":            cfg.NumRetries,
 	}).Info("Cli Config:")
 
 	log.Info("The smoothing pool at ", cfg.PoolAddress, " takes a cut of ", cfg.PoolFeesPercent, "% ensure you control the keys for ", cfg.PoolAddress, " to claim the fees")
@@ -191,28 +196,4 @@ func logConfig(cfg *Config) {
 	} else {
 		log.Warn("The pool contract will be updated. Make the account has balance to cover tx fees: ", cfg.UpdaterAddress)
 	}
-}
-
-// TODO: Unused
-func ReadHardcodedSubscriptions(filePath string) ([]uint64, error) {
-	preSubscribedIndexes := make([]uint64, 0)
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		line = strings.Replace(line, " ", "", -1)
-		if len(line) == 0 {
-			continue
-		}
-		valIndexUint64, err := strconv.ParseUint(line, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		preSubscribedIndexes = append(preSubscribedIndexes, valIndexUint64)
-	}
-	return preSubscribedIndexes, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,32 +16,8 @@ func CreateMockKeysFile(t *testing.T, customKeysFile string, content string) {
 	f.Close()
 }
 
-func Test_Legacy_0_Tx_Decode(t *testing.T) {
-	// Test file containing 4 validator indexes, one per line
-	fileName := "hardcoded_subscriptions.txt"
-	someValidatorIndexes := "1234\n2132\n890\n2343"
-	CreateMockKeysFile(t, fileName, someValidatorIndexes)
-	defer os.Remove(fileName)
+func Test_TODO(t *testing.T) {
 
-	indexes, err := ReadHardcodedSubscriptions(fileName)
-	require.NoError(t, err)
-	require.Equal(t, 4, len(indexes))
-	require.Equal(t, uint64(1234), indexes[0])
-	require.Equal(t, uint64(2132), indexes[1])
-	require.Equal(t, uint64(890), indexes[2])
-	require.Equal(t, uint64(2343), indexes[3])
-
-	// Test file containing 4 validator indexes, one per line, with extra line/space
-	fileName2 := "hardcoded_subscriptions.txt"
-	someValidatorIndexes2 := "1\n22\n8\n2\n " // <- extra line/space
-	CreateMockKeysFile(t, fileName2, someValidatorIndexes2)
-	defer os.Remove(fileName2)
-
-	indexes2, err := ReadHardcodedSubscriptions(fileName2)
-	require.NoError(t, err)
-	require.Equal(t, 4, len(indexes2))
-	require.Equal(t, uint64(1), indexes2[0])
-	require.Equal(t, uint64(22), indexes2[1])
-	require.Equal(t, uint64(8), indexes2[2])
-	require.Equal(t, uint64(2), indexes2[3])
+	require.Equal(t, 1, 1)
+	// TODO:
 }

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -755,10 +755,12 @@ func (o *Onchain) GetDepositAddressOfValidator(validatorPubKey string, slot uint
 
 func (o *Onchain) GetRetryOpts(opts []retry.Option) []retry.Option {
 	// Default retry options. This specifies what to do when a call to the
-	// consensus or execution client fails. Default is to retry 5 times
+	// consensus or execution client fails. Default is to retry x times (see config)
 	// with a 15 seconds delay and the default backoff strategy (see avas/retry-go)
 	// Note that in some cases we might want to avoid retrying at all, for example
 	// when serving data to an api, we may want to just fail fast and return an error
+	// If this function is called with retry options, we use those instead as a way
+	// to override the default retry options
 	if len(opts) == 0 {
 		return []retry.Option{
 			retry.Attempts(uint(o.Cfg.NumRetries)),

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -31,16 +31,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Default retry options. This specifies what to do when a call to the
-// consensus or execution client fails. Default is to retry 5 times
-// with a 15 seconds delay and the default backoff strategy (see avas/retry-go)
-// Note that in some cases we might want to avoid retrying at all, for example
-// when serving data to an api, we may want to just fail fast and return an error
-var defaultRetryOpts = []retry.Option{
-	retry.Attempts(5),
-	retry.Delay(15 * time.Second),
-}
-
 // This file provides different functions to access the blockchain state from both consensus and
 // execution layer and modifying the its state via smart contract calls.
 type EpochDuties struct {
@@ -60,6 +50,7 @@ type Onchain struct {
 	Cfg             *config.Config
 	Contract        *contract.Contract
 	Postgres        *postgres.Postgresql
+	NumRetries      int
 }
 
 func NewOnchain(cfg config.Config) (*Onchain, error) {
@@ -122,7 +113,7 @@ func NewOnchain(cfg config.Config) (*Onchain, error) {
 		return nil, errors.New("Error instantiating contract: " + err.Error())
 	}
 
-	postgres, err := postgres.New(cfg.PostgresEndpoint)
+	postgres, err := postgres.New(cfg.PostgresEndpoint, cfg.NumRetries)
 	if err != nil {
 		return nil, errors.New("Error instantiating postgres: " + err.Error())
 	}
@@ -136,32 +127,32 @@ func NewOnchain(cfg config.Config) (*Onchain, error) {
 	}, nil
 }
 
-func (f *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
+func (o *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
 	var err error
 	var execSync *ethereum.SyncProgress
 	var consSync *api.SyncState
 
 	err = retry.Do(func() error {
-		execSync, err = f.ExecutionClient.SyncProgress(context.Background())
+		execSync, err = o.ExecutionClient.SyncProgress(context.Background())
 		if err != nil {
 			log.Warn("Failed attempt to fetch execution client sync progress: ", err.Error(), " Retrying...")
 			return errors.New("Error fetching execution client sync progress: " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return false, errors.New("Could not fetch execution client sync progress: " + err.Error())
 	}
 
 	err = retry.Do(func() error {
-		consSync, err = f.ConsensusClient.NodeSyncing(context.Background())
+		consSync, err = o.ConsensusClient.NodeSyncing(context.Background())
 		if err != nil {
 			log.Warn("Failed attempt to fetch consensus client sync progress: ", err.Error(), " Retrying...")
 			return errors.New("Error fetching execution client sync progress: " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return false, errors.New("Could not fetch consensus client sync progress: " + err.Error())
@@ -175,19 +166,19 @@ func (f *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
 	return false, nil
 }
 
-func (f *Onchain) GetConsensusBlockAtSlot(slot uint64, opts ...retry.Option) (*spec.VersionedSignedBeaconBlock, error) {
+func (o *Onchain) GetConsensusBlockAtSlot(slot uint64, opts ...retry.Option) (*spec.VersionedSignedBeaconBlock, error) {
 	slotStr := strconv.FormatUint(slot, 10)
 	var signedBeaconBlock *spec.VersionedSignedBeaconBlock
 	var err error
 
 	err = retry.Do(func() error {
-		signedBeaconBlock, err = f.ConsensusClient.SignedBeaconBlock(context.Background(), slotStr)
+		signedBeaconBlock, err = o.ConsensusClient.SignedBeaconBlock(context.Background(), slotStr)
 		if err != nil {
 			log.Warn("Failed attempt to fetch block at slot ", slotStr, ": ", err.Error(), " Retrying...")
 			return errors.New("Error fetching block at slot " + slotStr + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("Could not fetch block at slot " + slotStr + ": " + err.Error())
@@ -196,18 +187,18 @@ func (f *Onchain) GetConsensusBlockAtSlot(slot uint64, opts ...retry.Option) (*s
 }
 
 // Given a validator key, returns the validator index
-func (f *Onchain) GetValidatorIndexByKey(valKey string, opts ...retry.Option) (uint64, error) {
+func (o *Onchain) GetValidatorIndexByKey(valKey string, opts ...retry.Option) (uint64, error) {
 	var err error
 	var validators map[phase0.ValidatorIndex]*api.Validator
 
 	err = retry.Do(func() error {
-		validators, err = f.ConsensusClient.ValidatorsByPubKey(context.Background(), "finalized", []phase0.BLSPubKey{StringToBlsKey(valKey)})
+		validators, err = o.ConsensusClient.ValidatorsByPubKey(context.Background(), "finalized", []phase0.BLSPubKey{StringToBlsKey(valKey)})
 		if err != nil {
 			log.Warn("Failed attempt to fetch validator index: ", err.Error(), " Retrying...")
 			return errors.New("Error fetching validator index: " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return 0, errors.New("Could not fetch validator index: " + err.Error())
@@ -224,18 +215,18 @@ func (f *Onchain) GetValidatorIndexByKey(valKey string, opts ...retry.Option) (u
 }
 
 // Given a validator index, returns the validator key
-func (f *Onchain) GetValidatorKeyByIndex(valIndex uint64, opts ...retry.Option) (string, error) {
+func (o *Onchain) GetValidatorKeyByIndex(valIndex uint64, opts ...retry.Option) (string, error) {
 	var err error
 	var validators map[phase0.ValidatorIndex]*api.Validator
 
 	err = retry.Do(func() error {
-		validators, err = f.ConsensusClient.Validators(context.Background(), "finalized", []phase0.ValidatorIndex{phase0.ValidatorIndex(valIndex)})
+		validators, err = o.ConsensusClient.Validators(context.Background(), "finalized", []phase0.ValidatorIndex{phase0.ValidatorIndex(valIndex)})
 		if err != nil {
 			log.Warn("Failed attempt to fetch validator key: ", err.Error(), " Retrying...")
 			return errors.New("Error fetching validator index: " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return "", errors.New("Could not fetch validator index: " + err.Error())
@@ -248,7 +239,7 @@ func (f *Onchain) GetValidatorKeyByIndex(valIndex uint64, opts ...retry.Option) 
 	return validator.Validator.PublicKey.String(), nil
 }
 
-func (f *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*api.ProposerDuty, error) {
+func (o *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*api.ProposerDuty, error) {
 	// Hardcoded value, slots in an epoch
 	slotsInEpoch := uint64(32)
 	epoch := slot / slotsInEpoch
@@ -270,14 +261,14 @@ func (f *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*api.Propo
 	var err error
 
 	err = retry.Do(func() error {
-		duties, err = f.ConsensusClient.ProposerDuties(
+		duties, err = o.ConsensusClient.ProposerDuties(
 			context.Background(), phase0.Epoch(epoch), indexes)
 		if err != nil {
 			log.Warn("Failed attempt to fetch proposal duties at slot ", slotStr, ": ", err.Error(), " Retrying...")
 			return errors.New("Error fetching proposal duties at slot " + slotStr + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("Error fetching proposal duties at slot " + slotStr + ": " + err.Error())
@@ -290,7 +281,7 @@ func (f *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*api.Propo
 }
 
 // This function is expensive as gets every tx receipt from the block. Use only if needed
-func (f *Onchain) GetExecHeaderAndReceipts(
+func (o *Onchain) GetExecHeaderAndReceipts(
 	blockNumber *big.Int,
 	rawTxs []bellatrix.Transaction,
 	opts ...retry.Option) (*types.Header, []*types.Receipt, error) {
@@ -299,13 +290,13 @@ func (f *Onchain) GetExecHeaderAndReceipts(
 	var err error
 
 	err = retry.Do(func() error {
-		header, err = f.ExecutionClient.HeaderByNumber(context.Background(), blockNumber)
+		header, err = o.ExecutionClient.HeaderByNumber(context.Background(), blockNumber)
 		if err != nil {
 			log.Warn("Failed attempt to fetch header for block ", blockNumber.String(), ": ", err.Error(), " Retrying...")
 			return errors.New("Error fetching header for block " + blockNumber.String() + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, nil, errors.New("Could not fetch header for block " + blockNumber.String() + ": " + err.Error())
@@ -321,13 +312,13 @@ func (f *Onchain) GetExecHeaderAndReceipts(
 		var receipt *types.Receipt
 
 		err = retry.Do(func() error {
-			receipt, err = f.ExecutionClient.TransactionReceipt(context.Background(), tx.Hash())
+			receipt, err = o.ExecutionClient.TransactionReceipt(context.Background(), tx.Hash())
 			if err != nil {
 				log.Warn("Failed attempt to fetch receipt for tx ", tx.Hash().String(), ": ", err.Error(), " Retrying...")
 				return errors.New("Error fetching receipt for tx " + tx.Hash().String() + ": " + err.Error())
 			}
 			return nil
-		}, GetRetryOpts(opts)...)
+		}, o.GetRetryOpts(opts)...)
 
 		if err != nil {
 			return nil, nil, errors.New("Could not fetch receipt for tx " + tx.Hash().String() + ": " + err.Error())
@@ -357,7 +348,7 @@ func (o *Onchain) GetDonationEvents(blockNumber uint64, opts ...retry.Option) ([
 			return errors.New("Error filtering donations for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("Could not filter donations for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
@@ -407,7 +398,7 @@ func (o *Onchain) GetBlockSubscriptions(blockNumber uint64, opts ...retry.Option
 			return errors.New("Error getting validator subscriptions for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("Error getting validator subscriptions for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
@@ -459,7 +450,7 @@ func (o *Onchain) GetBlockUnsubscriptions(blockNumber uint64, opts ...retry.Opti
 			return errors.New("Error getting validator unsubscriptions for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("Error getting validator unsubscriptions for block " + strconv.FormatUint(blockNumber, 10) + ": " + err.Error())
@@ -507,7 +498,7 @@ func (o *Onchain) GetContractMerkleRoot(opts ...retry.Option) (string, error) {
 			}
 			rewardsRootStr = "0x" + hex.EncodeToString(rewardsRoot[:])
 			return nil
-		}, GetRetryOpts(opts)...)
+		}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return "", errors.New("could not get merkle root from contract: " + err.Error())
@@ -528,7 +519,7 @@ func (o *Onchain) GetEthBalance(address string, opts ...retry.Option) (*big.Int,
 			return errors.New("could not get balance for address " + address + ": " + err.Error())
 		}
 		return nil
-	}, GetRetryOpts(opts)...)
+	}, o.GetRetryOpts(opts)...)
 
 	if err != nil {
 		return nil, errors.New("could not get balance for address " + address + ": " + err.Error())
@@ -762,9 +753,17 @@ func (o *Onchain) GetDepositAddressOfValidator(validatorPubKey string, slot uint
 	return someDepositAddresses[slot%7]
 }
 
-func GetRetryOpts(opts []retry.Option) []retry.Option {
+func (o *Onchain) GetRetryOpts(opts []retry.Option) []retry.Option {
+	// Default retry options. This specifies what to do when a call to the
+	// consensus or execution client fails. Default is to retry 5 times
+	// with a 15 seconds delay and the default backoff strategy (see avas/retry-go)
+	// Note that in some cases we might want to avoid retrying at all, for example
+	// when serving data to an api, we may want to just fail fast and return an error
 	if len(opts) == 0 {
-		return defaultRetryOpts
+		return []retry.Option{
+			retry.Attempts(uint(o.Cfg.NumRetries)),
+			retry.Delay(15 * time.Second),
+		}
 	} else {
 		return opts
 	}

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -3,9 +3,10 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"strings"
+	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
@@ -15,11 +16,12 @@ import (
 // This file is outdated and some of these functions are not used
 
 type Postgresql struct {
-	Db *pgx.Conn
+	Db         *pgx.Conn
+	NumRetries int
 }
 
 // postgres://xxx:yyy@url:5432
-func New(postgresEndpoint string) (*Postgresql, error) {
+func New(postgresEndpoint string, numRetries int) (*Postgresql, error) {
 	var conn *pgx.Conn
 	var err error
 	if postgresEndpoint != "" {
@@ -31,22 +33,27 @@ func New(postgresEndpoint string) (*Postgresql, error) {
 	}
 
 	return &Postgresql{
-		Db: conn,
+		Db:         conn,
+		NumRetries: numRetries,
 	}, nil
 }
 
 // Returns the validator keys for the given deposit addresses
-func (a *Postgresql) GetValidatorKeysFromDepositAddress(fromAddresses []string) ([][]byte, error) {
-	rows, err := a.Db.Query(context.Background(),
-		`select encode(f_validator_pubkey, 'hex')
+func (a *Postgresql) GetValidatorKeysFromDepositAddress(fromAddresses []string, opts ...retry.Option) ([][]byte, error) {
+	var err error
+	var rows pgx.Rows
+
+	err = retry.Do(func() error {
+		rows, err = a.Db.Query(context.Background(),
+			`select encode(f_validator_pubkey, 'hex')
 		from t_eth1_deposits
 		where (`+getDepositsWhereClause(fromAddresses)+")")
-
-	if err != nil {
-		return nil, errors.Wrap(err,
-			fmt.Sprintf("%s: %s", "could not get keys for pool",
-				fromAddresses))
-	}
+		if err != nil {
+			log.Warn("Retrying get validator keys from deposit address: ", fromAddresses)
+			return errors.Wrap(err, "could not get keys for pool")
+		}
+		return nil
+	}, a.GetRetryOpts(opts)...)
 
 	keys := make([][]byte, 0)
 	defer rows.Close()
@@ -68,82 +75,24 @@ func (a *Postgresql) GetValidatorKeysFromDepositAddress(fromAddresses []string) 
 	return keys, nil
 }
 
-// Returns the latest known checkpoint root and slot
-func (a *Postgresql) GetLatestCheckpoint() (string, uint64, error) {
-	var latestCheckpointRoot string
-	var checkpointSlot uint64
-
-	err := a.Db.QueryRow(context.Background(),
-		"select f_checkpoint_root,f_checkpoint_slot from t_oracle_validator_balances where f_checkpoint_slot = (select max(f_checkpoint_slot) from t_oracle_validator_balances) limit 1").Scan(&latestCheckpointRoot, &checkpointSlot)
-	if err != nil {
-		return "", 0, err
-	}
-	return latestCheckpointRoot, checkpointSlot, nil
-}
-
 // Given a validator key in hex prefixed with 0x, return its deposit address
 // also with 0x prefix
-func (a *Postgresql) GetDepositAddressOfValidatorKey(validatorKey string) (string, error) {
+func (a *Postgresql) GetDepositAddressOfValidatorKey(validatorKey string, opts ...retry.Option) (string, error) {
 	var depositAddress string
-	err := a.Db.QueryRow(context.Background(),
-		"select encode(f_eth1_sender, 'hex') from t_eth1_deposits where encode(f_validator_pubkey::bytea, 'hex') = $1",
-		strings.Replace(validatorKey, "0x", "", -1)).Scan(&depositAddress)
+	var err error
 
-	if err != nil {
-		return "", err
-	}
+	err = retry.Do(func() error {
+		err = a.Db.QueryRow(context.Background(),
+			"select encode(f_eth1_sender, 'hex') from t_eth1_deposits where encode(f_validator_pubkey::bytea, 'hex') = $1",
+			strings.Replace(validatorKey, "0x", "", -1)).Scan(&depositAddress)
+		if err != nil {
+			log.Warn("Retrying get deposit address of validator key: ", validatorKey)
+			return errors.Wrap(err, "could not get deposit address of validator key")
+		}
+		return nil
+	}, a.GetRetryOpts(opts)...)
+
 	return "0x" + depositAddress, nil
-}
-
-// Gets the merkle proofs for a given deposit address for the latest known checkpoint (slot)
-// Deposit address should be prefixed with 0x
-func (a *Postgresql) GetLatestMerkleProofByDeposit(depositAddress string) ([]string, string, uint64, string, string, error) {
-	// TODO: Get also merkle root
-	// TODO: check if not starts with 0x, return err
-	var merkleRoots string
-	var merkleRoot string
-	var checkpointSlot uint64
-	var availableBalance string // TODO: perhaps bigInt is better workaround
-	var unbanBalance string     // TODO: perhaps bigInt is better workaround
-
-	// TODO: CAST(f_claimable_balance as TEXT) dirty workaround. Find a better way
-	log.Info("depositAddress:", depositAddress)
-	err := a.Db.QueryRow(context.Background(),
-		"select f_checkpoint_proofs, f_checkpoint_root, f_checkpoint_slot, CAST(f_claimable_balance as TEXT), CAST(f_unban_balance as TEXT) from t_oracle_depositaddress_rewards where LOWER(f_deposit_address) = $1 and f_checkpoint_slot = (select max(f_checkpoint_slot) from t_oracle_depositaddress_rewards)",
-		strings.ToLower(depositAddress)).Scan(&merkleRoots, &merkleRoot, &checkpointSlot, &availableBalance, &unbanBalance)
-
-	if err != nil {
-		return []string{}, "", 0, "", "", err
-	}
-
-	// TODO: add some validation
-	return strings.Split(merkleRoots, ","), merkleRoot, checkpointSlot, availableBalance, unbanBalance, err
-}
-
-// TODO: passing everything, dirty
-func (a *Postgresql) StoreBlockInDb(
-	timestamp string,
-	slot uint64,
-	validatorKey string,
-	validatorIndex uint64,
-	vanilaOrMev string,
-	rewardWei big.Int,
-	okWrongMissed uint64) error {
-	_, err := a.Db.Exec(
-		context.Background(),
-		InsertBlocksTable,
-		timestamp,
-		slot,
-		validatorKey,
-		validatorIndex,
-		vanilaOrMev,
-		rewardWei.Uint64(), // TODO can overflow
-		okWrongMissed,
-	)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func getDepositsWhereClause(fromAddresses []string) string {
@@ -157,97 +106,18 @@ func getDepositsWhereClause(fromAddresses []string) string {
 	return strings.Join(whereElements, " or ")
 }
 
-// TODO: rename to validatorRewards vs DepositAddressRewards
-// TODO remove the proofs from here.
-var CreateRewardsTable = `
-CREATE TABLE IF NOT EXISTS t_oracle_validator_balances (
-	 f_deposit_address TEXT,
-	 f_validator_key TEXT,
-	 f_validator_index NUMERIC,
-	 f_pending_balance BIGINT,
-	 f_claimable_balance BIGINT,
-	 f_unban_balance BIGINT,
-	 f_num_proposed_blocks BIGINT,
-	 f_num_missed_blocks BIGINT,
-	 f_num_wrongfee_blocks BIGINT,
-	 f_checkpoint_slot BIGINT,
-	 f_checkpoint_proofs TEXT,
-	 f_checkpoint_root TEXT,
-
-	 PRIMARY KEY (f_validator_key, f_checkpoint_slot)
-);
-`
-
-// TODO: pool recipient address no longer exists
-// TODO: pending is not populated now, but a nice to have.
-var CreateDepositAddressRewardsTable = `
-CREATE TABLE IF NOT EXISTS t_oracle_depositaddress_rewards (
-	 f_deposit_address TEXT,
-	 f_validator_keys TEXT,
-	 f_pending_balance BIGINT,
-	 f_claimable_balance BIGINT,
-	 f_unban_balance BIGINT,
-	 f_checkpoint_slot BIGINT,
-	 f_checkpoint_proofs TEXT,
-	 f_checkpoint_root TEXT,
-
-	 PRIMARY KEY (f_deposit_address, f_checkpoint_slot)
-);
-`
-
-var CreateBlocksTable = `
-CREATE TABLE IF NOT EXISTS t_pool_blocks (
-	f_timestamp TEXT,
-	f_slot NUMERIC,
-	f_validator_key TEXT,
-	f_validator_index NUMERIC,
-	f_vanila_or_mev TEXT,
-	f_reward_wei BIGINT,
-	f_ok_wrong_missed NUMERIC,
-
-	PRIMARY KEY (f_slot)
-);
-`
-
-// TODO: add validator state?
-var InsertRewardsTable = `
-INSERT INTO t_oracle_validator_balances(
-	f_deposit_address,
-	f_validator_key,
-	f_validator_index,
-	f_pending_balance,
-	f_claimable_balance,
-	f_unban_balance,
-	f_num_proposed_blocks,
-	f_num_missed_blocks,
-	f_num_wrongfee_blocks,
-	f_checkpoint_slot,
-	f_checkpoint_proofs,
-	f_checkpoint_root)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-`
-
-var InsertBlocksTable = `
-INSERT INTO t_pool_blocks(
-	f_timestamp,
-	f_slot,
-	f_validator_key,
-	f_validator_index,
-	f_vanila_or_mev,
-	f_reward_wei,
-	f_ok_wrong_missed)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-`
-
-var InsertDepositAddressRewardsTable = `
-INSERT INTO t_oracle_depositaddress_rewards(
-	f_deposit_address,
-	f_validator_keys,
-	f_pending_balance,
-	f_claimable_balance,
-	f_unban_balance,
-	f_checkpoint_slot,
-	f_checkpoint_proofs,
-	f_checkpoint_root)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-`
+func (a *Postgresql) GetRetryOpts(opts []retry.Option) []retry.Option {
+	// Default retry options. This specifies what to do when a call to the
+	// consensus or execution client fails. Default is to retry 5 times
+	// with a 15 seconds delay and the default backoff strategy (see avas/retry-go)
+	// Note that in some cases we might want to avoid retrying at all, for example
+	// when serving data to an api, we may want to just fail fast and return an error
+	if len(opts) == 0 {
+		return []retry.Option{
+			retry.Attempts(uint(a.NumRetries)),
+			retry.Delay(15 * time.Second),
+		}
+	} else {
+		return opts
+	}
+}

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -108,10 +108,12 @@ func getDepositsWhereClause(fromAddresses []string) string {
 
 func (a *Postgresql) GetRetryOpts(opts []retry.Option) []retry.Option {
 	// Default retry options. This specifies what to do when a call to the
-	// consensus or execution client fails. Default is to retry 5 times
+	// consensus or execution client fails. Default is to retry x times (see config)
 	// with a 15 seconds delay and the default backoff strategy (see avas/retry-go)
 	// Note that in some cases we might want to avoid retrying at all, for example
 	// when serving data to an api, we may want to just fail fast and return an error
+	// If this function is called with retry options, we use those instead as a way
+	// to override the default retry options
 	if len(opts) == 0 {
 		return []retry.Option{
 			retry.Attempts(uint(a.NumRetries)),

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_GetValidatorKeysFromDepositAddress(t *testing.T) {
 	t.Skip("Skipping e2e test")
-	db, err := New("postgres://xxx:yyy@localhost:5432")
+	db, err := New("postgres://xxx:yyy@localhost:5432", 1)
 	require.NoError(t, err)
 	fromAdd, err := db.GetValidatorKeysFromDepositAddress([]string{"0x4554f8ca6104a361f20e75213d980f7ee56b24c3"})
 	require.NoError(t, err)
@@ -21,7 +21,7 @@ func Test_GetValidatorKeysFromDepositAddress(t *testing.T) {
 
 func Test_GetDepositAddressOfValidator(t *testing.T) {
 	t.Skip("Skipping e2e test")
-	db, err := New("postgres://xxx:yyy@localhost:5432")
+	db, err := New("postgres://xxx:yyy@localhost:5432", 1)
 	require.NoError(t, err)
 	depositAddress, err := db.GetDepositAddressOfValidatorKey("0x858dff42301025ce01ac3ac6389b9a1a9020c210ef2ca2a21d17337729cf17e4bceca64aa6413c01d82d145bf1505116")
 	require.NoError(t, err)


### PR DESCRIPTION
* Add flag to customize the number of retries before panic for consensus, execution and postgres endpoints.
* Add retry capabilities to postgres endpoint (was missing).