### PR TITLE
Fix donation not confused mev-rewards

### DIFF
--- a/oracle/block_test.go
+++ b/oracle/block_test.go
@@ -245,6 +245,25 @@ func Test_DonatedAmountInWei_Slot_5320342(t *testing.T) {
 	require.Equal(t, donation2, big.NewInt(3648455520393139))
 }
 
+func Test_GetDonations(t *testing.T) {
+
+	fileName := "bellatrix_slot_5320342_mainnet"
+	block, _, _ := LoadBlockHeaderReceiptsBellatrix(t, fileName)
+	extendedBlock := spec.VersionedSignedBeaconBlock{Bellatrix: &block}
+	myBlock := VersionedSignedBeaconBlock{&extendedBlock}
+
+	// one donation is sent to this addres: 0x023aa0a3a580e7f3b4bcbb716e0fb6efd86ed25e
+	donations := myBlock.GetDonations("0x023aa0a3a580e7f3b4bcbb716e0fb6efd86ed25e")
+
+	number, ok := new(big.Int).SetString("20000000000000000000", 10)
+	require.Equal(t, ok, true)
+	require.Equal(t, len(donations), 1)
+	require.Equal(t, number, donations[0].AmountWei)
+	require.Equal(t, uint64(16153707), donations[0].Block)
+	require.Equal(t, "0x49b86d86afaf59de4e1707d91f2cc19c387a421e10d0751c66669c02c494d9d8", donations[0].TxHash)
+
+}
+
 // Util to load from file
 func LoadBlockHeaderReceiptsBellatrix(t *testing.T, file string) (bellatrix.SignedBeaconBlock, types.Header, []*types.Receipt) {
 	blockJson, err := os.Open("../mock/block_" + file)

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -331,6 +331,7 @@ func (o *Onchain) GetExecHeaderAndReceipts(
 // TODO: Rethink this function. Its not just donations but eth rx to the contract
 // in general
 func (o *Onchain) GetDonationEvents(blockNumber uint64, opts ...retry.Option) ([]Donation, error) {
+	log.Fatal("This function is deprecated. Use GetDonations instead")
 	startBlock := uint64(blockNumber)
 	endBlock := uint64(blockNumber)
 
@@ -604,10 +605,12 @@ func (o *Onchain) GetAllBlockInfo(slot uint64) (Block, []Subscription, []Unsubsc
 
 	// TODO: This is wrong, as this event will also be triggered when a validator proposes a MEV block
 	// Fetch donations in this block
-	blockDonations, err := o.GetDonationEvents(extendedBlock.GetBlockNumber())
-	if err != nil {
-		log.Fatal("could not get block donations: ", err)
-	}
+	//blockDonations, err := o.GetDonationEvents(extendedBlock.GetBlockNumber())
+	//if err != nil {
+	//	log.Fatal("could not get block donations: ", err)
+	//}
+
+	blockDonations := extendedBlock.GetDonations(o.Cfg.PoolAddress)
 
 	return poolBlock, blockSubs, blockUnsubs, blockDonations
 }


### PR DESCRIPTION
* Donations can be confused with mev-reward if using the EtherReceived event.
* This PR stops using the event for donations.
* Donations are now calculated by checking transactions within each block.
* This doesn't detect the donations made via a smart contract, pending.