### PR TITLE
Add matching collateral + get onchain contract subscriptionCollateral method

### DIFF
--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -485,6 +485,26 @@ func (o *Onchain) GetBlockUnsubscriptions(blockNumber uint64, opts ...retry.Opti
 	return blockUnsubscriptions, nil
 }
 
+func (o *Onchain) GetContractCollateral(opts ...retry.Option) (*big.Int, error) {
+	subscriptionCollateral := new(big.Int)
+	err := retry.Do(
+		func() error {
+			callOpts := &bind.CallOpts{Context: context.Background(), Pending: false}
+			var err error
+			subscriptionCollateral, err = o.Contract.SuscriptionCollateral(callOpts)
+			if err != nil {
+				log.Warn("Failed attempt to get subscription collateral from contract: ", err.Error(), " Retrying...")
+				return errors.New("could not get subscription collateral from contract: " + err.Error())
+			}
+			return nil
+		}, o.GetRetryOpts(opts)...)
+
+	if err != nil {
+		return big.NewInt(0), errors.New("could not get subscription collateral from contract: " + err.Error())
+	}
+	return subscriptionCollateral, nil
+}
+
 func (o *Onchain) GetContractMerkleRoot(opts ...retry.Option) (string, error) {
 	var rewardsRootStr string
 

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -675,7 +675,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 			state.Validators[valIndex].ValidatorStatus = YellowCard
 		case Unsubscribe:
 			log.WithFields(log.Fields{
-				"Event":          "ProposalMissed",
+				"Event":          "Unsubscribe",
 				"StateChange":    "Active -> NotSubscribed",
 				"ValidatorIndex": valIndex,
 				"Slot":           state.LatestSlot,
@@ -710,7 +710,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 			state.Validators[valIndex].ValidatorStatus = RedCard
 		case Unsubscribe:
 			log.WithFields(log.Fields{
-				"Event":           "ProposalMissed",
+				"Event":           "Unsubscribe",
 				"StateChange":     "YellowCard -> NotSubscribed",
 				"ValidatorIndex:": valIndex,
 				"Slot":            state.LatestSlot,
@@ -745,7 +745,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 			state.Validators[valIndex].ValidatorStatus = RedCard
 		case Unsubscribe:
 			log.WithFields(log.Fields{
-				"Event":           "ProposalMissed",
+				"Event":           "Unsubscribe",
 				"StateChange":     "RedCard -> NotSubscribed",
 				"ValidatorIndex:": valIndex,
 				"Slot":            state.LatestSlot,


### PR DESCRIPTION


Ensure that configured oracle collateral is equal to collateral of the smart contract on chain. Ceck done at the beginning of main.
Not sure about how to manage the error. Should it be a fatal or simply a warning?

Added a method on onchain.go that gets the subscriptionCollateral variable of the smart contract (very similar to the method right below it that gets merkle root, line 508 (https://github.com/dappnode/mev-sp-oracle/compare/matching_collateral?expand=1#diff-50e7e8c9ebde3c86e2e8fb607502007aa9e39ef74fa9facdbc7611fe25f20c73R508)