### PR TITLE
Rename deposit to withdrawal

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -49,7 +49,7 @@ curl 157.90.93.245:7300/memory/validator/408120
 Return information of all subscribed validators from a withdrawal address, including validators not tracked by the pool
 
 ```
-curl 157.90.93.245:7300/memory/validators/0xa111b576408b1ccdaca3ef26f22f082c49bcaa55
+curl 157.90.93.245:7300/memory/validators/0xa111B576408B1CcDacA3eF26f22f082C49bcaa55
 ```
 
 Returns information on the fees that the pool takes, such as percent, address and fees so far.

--- a/oracle/merklelizer_test.go
+++ b/oracle/merklelizer_test.go
@@ -19,27 +19,27 @@ func Test_GenerateTreeFromState(t *testing.T) {
 	// Note that the leafs contain also PoolAddress at the begining
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0x1000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x1000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0x2000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x2000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(20000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0x3000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x3000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0x4000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x4000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0x5000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x5000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0x6000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x6000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 
@@ -58,57 +58,57 @@ func Test_AggregateValidatorsIndexes_NoAggregation(t *testing.T) {
 	state.PoolAccumulatedFees = big.NewInt(999999999999999)
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0x1000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x1000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0x2000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x2000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(20000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0x3000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x3000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0x4000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x4000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0x5000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x5000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0x6000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x6000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x0000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x0000000000000000000000000000000000000000",
 			AccumulatedBalance: big.NewInt(999999999999999),
 		},
 		{
-			DepositAddress:     "0x1000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x1000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(10000),
 		},
 		{
-			DepositAddress:     "0x2000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x2000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(20000),
 		},
 		{
-			DepositAddress:     "0x3000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x3000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(30000),
 		},
 		{
-			DepositAddress:     "0x4000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x4000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(40000),
 		},
 		{
-			DepositAddress:     "0x5000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x5000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(50000),
 		},
 		{
-			DepositAddress:     "0x6000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x6000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(60000),
 		},
 	}
@@ -127,57 +127,57 @@ func Test_AggregateValidatorsIndexes_NoAggregationOrdered(t *testing.T) {
 	state.PoolAccumulatedFees = big.NewInt(2345678987654)
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0x3000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x3000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0x6000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x6000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0x1000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x1000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0x2000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x2000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(20000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0x4000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x4000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0x5000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0x5000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x0000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x0000000000000000000000000000000000000000",
 			AccumulatedBalance: big.NewInt(2345678987654),
 		},
 		{
-			DepositAddress:     "0x1000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x1000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(10000),
 		},
 		{
-			DepositAddress:     "0x2000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x2000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(20000),
 		},
 		{
-			DepositAddress:     "0x3000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x3000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(30000),
 		},
 		{
-			DepositAddress:     "0x4000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x4000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(40000),
 		},
 		{
-			DepositAddress:     "0x5000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x5000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(50000),
 		},
 		{
-			DepositAddress:     "0x6000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x6000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(60000),
 		},
 	}
@@ -198,37 +198,37 @@ func Test_AggregateValidatorsIndexes_AggregationAll(t *testing.T) {
 	state.PoolAccumulatedFees = big.NewInt(0)
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(20000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x0000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x0000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(0),
 		},
 		{
-			DepositAddress:     "0xaa00000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xaa00000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(210000),
 		},
 	}
@@ -248,42 +248,42 @@ func Test_AggregateValidatorsIndexes_Aggregation_And_Leftover(t *testing.T) {
 	state.PoolAccumulatedFees = new(big.Int).SetUint64(1)
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0xaa00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xaa00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0xbb00000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xbb00000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(500000),
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x0000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x0000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(1),
 		},
 		{
-			DepositAddress:     "0xaa00000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xaa00000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(190000),
 		},
 		{
-			DepositAddress:     "0xbb00000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xbb00000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(500000),
 		},
 	}
@@ -301,61 +301,61 @@ func Test_AggregateValidatorsIndexes_Aggregation_NoOrder(t *testing.T) {
 	state.PoolAccumulatedFees = big.NewInt(234567)
 
 	state.Validators[0] = &ValidatorInfo{
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(30000),
 	}
 	state.Validators[1] = &ValidatorInfo{
-		DepositAddress:        "0xb000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xb000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(60000),
 	}
 	state.Validators[2] = &ValidatorInfo{
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(10000),
 	}
 	state.Validators[3] = &ValidatorInfo{
-		DepositAddress:        "0xc000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xc000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[4] = &ValidatorInfo{
-		DepositAddress:        "0xc000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xc000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[5] = &ValidatorInfo{
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(40000),
 	}
 	state.Validators[6] = &ValidatorInfo{
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[7] = &ValidatorInfo{
-		DepositAddress:        "0xc000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xc000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[8] = &ValidatorInfo{
-		DepositAddress:        "0xb000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xb000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 	state.Validators[9] = &ValidatorInfo{
-		DepositAddress:        "0xb000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xb000000000000000000000000000000000000000",
 		AccumulatedRewardsWei: big.NewInt(50000),
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x0000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x0000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(234567),
 		},
 		{
-			DepositAddress:     "0xa000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xa000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(130000),
 		},
 		{
-			DepositAddress:     "0xb000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xb000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(160000),
 		},
 		{
-			DepositAddress:     "0xc000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xc000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(140000),
 		},
 	}
@@ -364,55 +364,55 @@ func Test_AggregateValidatorsIndexes_Aggregation_NoOrder(t *testing.T) {
 	require.Equal(t, expected, rawLeafs)
 }
 
-func Test_OrderByDepositAddress(t *testing.T) {
+func Test_OrderByWithdrawalAddress(t *testing.T) {
 	merklelizer := NewMerklelizer()
 
 	leafs := []RawLeaf{
 		{
-			DepositAddress:     "0x3000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x3000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(1),
 		},
 		{
-			DepositAddress:     "0x5000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x5000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(3),
 		},
 		{
-			DepositAddress:     "0x1000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x1000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 		{
-			DepositAddress:     "0xa000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xa000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 		{
-			DepositAddress:     "0x9900000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x9900000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 	}
 
 	expected := []RawLeaf{
 		{
-			DepositAddress:     "0x1000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x1000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 		{
-			DepositAddress:     "0x3000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x3000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(1),
 		},
 		{
-			DepositAddress:     "0x5000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x5000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(3),
 		},
 		{
-			DepositAddress:     "0x9900000000000000000000000000000000000000",
+			WithdrawalAddress:  "0x9900000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 		{
-			DepositAddress:     "0xa000000000000000000000000000000000000000",
+			WithdrawalAddress:  "0xa000000000000000000000000000000000000000",
 			AccumulatedBalance: new(big.Int).SetUint64(5),
 		},
 	}
 
-	ordered := merklelizer.OrderByDepositAddress(leafs)
+	ordered := merklelizer.OrderByWithdrawalAddress(leafs)
 	require.Equal(t, expected, ordered)
 }

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -444,15 +444,15 @@ func (o *Onchain) GetContractMerkleRoot(opts ...retry.Option) (string, error) {
 }
 
 // TODO: Only in finalized slots!
-func (o *Onchain) GetContractClaimedBalance(depositAddress string, opts ...retry.Option) (*big.Int, error) {
+func (o *Onchain) GetContractClaimedBalance(WithdrawalAddress string, opts ...retry.Option) (*big.Int, error) {
 	var claimedBalance *big.Int
 	var err error
 
-	if !common.IsHexAddress(depositAddress) {
-		log.Fatal("Invalid deposit address: ", depositAddress)
+	if !common.IsHexAddress(WithdrawalAddress) {
+		log.Fatal("Invalid withdrawal address: ", WithdrawalAddress)
 	}
 
-	hexDepAddres := common.HexToAddress(depositAddress)
+	hexDepAddres := common.HexToAddress(WithdrawalAddress)
 
 	// Retries multiple times before errorings
 	err = retry.Do(
@@ -557,7 +557,7 @@ func (o *Onchain) GetAllBlockInfo(slot uint64) (Block, []Subscription, []Unsubsc
 				poolBlock.BlockType = OkPoolProposalBlsKeys
 			} else {
 				poolBlock.BlockType = OkPoolProposal
-				poolBlock.DepositAddress = withdrawalAddress
+				poolBlock.WithdrawalAddress = withdrawalAddress
 			}
 		} else {
 			poolBlock.BlockType = WrongFeeRecipient

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -46,7 +46,7 @@ func Test_Oracle_ManualSubscription(t *testing.T) {
 		block1 := Block{
 			Slot: uint64(50011), ValidatorIndex: uint64(400000),
 			ValidatorKey: "0xval_400000", BlockType: OkPoolProposal,
-			Reward: big.NewInt(245579896737171752), RewardType: MevBlock, DepositAddress: "0xaaa0000000000000000000000000000000000000",
+			Reward: big.NewInt(245579896737171752), RewardType: MevBlock, WithdrawalAddress: "0xaaa0000000000000000000000000000000000000",
 		}
 
 		processedSlot, err = oracle.AdvanceStateToNextSlot(block1, []Subscription{}, []Unsubscription{}, []Donation{})
@@ -57,7 +57,7 @@ func Test_Oracle_ManualSubscription(t *testing.T) {
 		block2 := Block{
 			Slot: uint64(50012), ValidatorIndex: uint64(500000),
 			ValidatorKey: "0xval_500000", BlockType: OkPoolProposal,
-			Reward: big.NewInt(945579196337171700), RewardType: MevBlock, DepositAddress: "0xaaa0000000000000000000000000000000000000",
+			Reward: big.NewInt(945579196337171700), RewardType: MevBlock, WithdrawalAddress: "0xaaa0000000000000000000000000000000000000",
 		}
 
 		processedSlot, err = oracle.AdvanceStateToNextSlot(block2, []Subscription{}, []Unsubscription{}, []Donation{})
@@ -188,7 +188,7 @@ func Test_100_slots_test(t *testing.T) {
 					"ValidatorIndex":  sub.ValidatorIndex,
 					"ValidatorKey":    sub.ValidatorKey,
 					"Collateral":      sub.Collateral,
-					"Deposit Address": sub.DepositAddress,
+					"withdrawal address": sub.WithdrawalAddress,
 					"Tx Hash":         sub.TxHash,
 				}).Info("Mocked Event: Subscription")
 			}
@@ -198,7 +198,7 @@ func Test_100_slots_test(t *testing.T) {
 					"ValidatorIndex":  unsub.ValidatorIndex,
 					"ValidatorKey":    unsub.ValidatorKey,
 					"Sender":          unsub.Sender,
-					"Deposit Address": unsub.DepositAddress,
+					"withdrawal address": unsub.WithdrawalAddress,
 					"Tx Hash":         unsub.TxHash,
 				}).Info("Mocked Event: Unsubscription")
 			}
@@ -322,7 +322,7 @@ func GenerateSubsctiptions(
 			Collateral:     collateral[i],
 			BlockNumber:    blockNum[i],
 			TxHash:         txHash[i],
-			DepositAddress: depAdd[i],
+			WithdrawalAddress: depAdd[i],
 		})
 	}
 	return subs
@@ -342,7 +342,7 @@ func GenerateUnsunscriptions(
 			Sender:         sender[i],
 			BlockNumber:    blockNum[i],
 			TxHash:         txHashes[i],
-			DepositAddress: depAdd[i],
+			WithdrawalAddress: depAdd[i],
 		})
 	}
 	return unsubs
@@ -366,14 +366,14 @@ func WrongFeeBlock(slot uint64, valIndex uint64, pubKey string) Block {
 	}
 }
 
-func blockOkProposal(slot uint64, valIndex uint64, pubKey string, reward *big.Int, depAddr string) Block {
+func blockOkProposal(slot uint64, valIndex uint64, pubKey string, reward *big.Int, withAddress string) Block {
 	return Block{
-		Slot:           slot,
-		ValidatorIndex: valIndex,
-		ValidatorKey:   pubKey,
-		BlockType:      OkPoolProposal,
-		Reward:         reward,
-		RewardType:     MevBlock,
-		DepositAddress: depAddr,
+		Slot:              slot,
+		ValidatorIndex:    valIndex,
+		ValidatorKey:      pubKey,
+		BlockType:         OkPoolProposal,
+		Reward:            reward,
+		RewardType:        MevBlock,
+		WithdrawalAddress: withAddress,
 	}
 }

--- a/oracle/oraclestate_test.go
+++ b/oracle/oraclestate_test.go
@@ -81,7 +81,7 @@ func Test_HandleManualSubscriptions_Valid(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(0),
 		PendingRewardsWei:       big.NewInt(1000),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          33,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -127,7 +127,7 @@ func Test_HandleManualSubscriptions_AlreadySubscribed(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(2000), // Second and third collateral are returned to the user
 		PendingRewardsWei:       big.NewInt(1000),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          33,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -180,7 +180,7 @@ func Test_HandleManualSubscriptions_AlreadySubscribed_WithBalance(t *testing.T) 
 		AccumulatedRewardsWei:   big.NewInt(9000 + 1000*2),
 		PendingRewardsWei:       big.NewInt(44000 + 1000),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          33,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -309,7 +309,7 @@ func Test_HandleManualSubscriptions_BannedValidator(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(0),
 		PendingRewardsWei:       big.NewInt(0),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          bannedIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -344,7 +344,7 @@ func Test_HandleManualSubscriptions_BannedValidator(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(1000),
 		PendingRewardsWei:       big.NewInt(0),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          bannedIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -414,7 +414,7 @@ func Test_HandleUnsubscriptions_ValidSubscription(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(3000), // Accumulated rewards are kept
 		PendingRewardsWei:       big.NewInt(0),    // Pending rewards are cleared
 		CollateralWei:           big.NewInt(500000),
-		DepositAddress:          "0x0627a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x0627a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          6,
 		ValidatorKey:            "0x06aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -492,7 +492,7 @@ func Test_HandleUnsubscriptions_NonExistentValidator(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(9000 + 1000*2), // Second and third collateral are added to accumulated rewards (returned)
 		PendingRewardsWei:       big.NewInt(44000 + 1000),  // First collateral is added to pending (claimable in next block)
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          33,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -519,7 +519,7 @@ func Test_HandleUnsubscriptions_NonExistentValidator(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(9000 + 1000*2), // Second and third collateral are added to accumulated rewards (returned)
 		PendingRewardsWei:       big.NewInt(44000 + 1000),  // First collateral is added to pending (claimable in next block)
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          33,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -574,7 +574,7 @@ func Test_HandleUnsubscriptions_FromWrongAddress(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(5000000000000000000),
 		PendingRewardsWei:       big.NewInt(3000000000000000000),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          valIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -607,7 +607,7 @@ func Test_HandleUnsubscriptions_FromWrongAddress(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(5000000000000000000),
 		PendingRewardsWei:       big.NewInt(3000000000000000000),
 		CollateralWei:           big.NewInt(1000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          valIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -631,7 +631,7 @@ func Test_Unsubscribe_AndRejoin(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(0),
 		PendingRewardsWei:       big.NewInt(0),
 		CollateralWei:           big.NewInt(500000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          valIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -669,7 +669,7 @@ func Test_Unsubscribe_AndRejoin(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(1000000000000000000),
 		PendingRewardsWei:       big.NewInt(0),
 		CollateralWei:           big.NewInt(500000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          valIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -703,7 +703,7 @@ func Test_Unsubscribe_AndRejoin(t *testing.T) {
 		AccumulatedRewardsWei:   big.NewInt(1000000000000000000),
 		PendingRewardsWei:       big.NewInt(500000),
 		CollateralWei:           big.NewInt(500000),
-		DepositAddress:          "0x9427a30991170f917d7b83def6e44d26577871ed",
+		WithdrawalAddress:       "0x9427a30991170f917d7b83def6e44d26577871ed",
 		ValidatorIndex:          valIndex,
 		ValidatorKey:            "0x81aae709e6aee7ed49cd15b941d85b967afcc8b844ee20bc7e13962e8484572c1b43d4be75652119ec353c1a32443e0d",
 		ValidatorProposedBlocks: []Block{},
@@ -862,7 +862,7 @@ func Test_ResetPendingRewards(t *testing.T) {
 func Test_IncreasePendingRewards(t *testing.T) {
 	state := NewOracleState(&config.Config{})
 	state.Validators[12] = &ValidatorInfo{
-		DepositAddress:    "0xaa",
+		WithdrawalAddress: "0xaa",
 		ValidatorStatus:   Active,
 		PendingRewardsWei: big.NewInt(100),
 	}
@@ -985,7 +985,7 @@ func Test_SaveLoadFromToFile_PopulatedState(t *testing.T) {
 		AccumulatedRewardsWei: big.NewInt(1000),
 		PendingRewardsWei:     big.NewInt(1000),
 		CollateralWei:         big.NewInt(1000),
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		ValidatorIndex:        10,
 		ValidatorKey:          "0xc", // TODO: Fix this, should be uint64
 		ValidatorProposedBlocks: []Block{
@@ -1027,7 +1027,7 @@ func Test_SaveLoadFromToFile_PopulatedState(t *testing.T) {
 		AccumulatedRewardsWei: big.NewInt(13000),
 		PendingRewardsWei:     big.NewInt(100),
 		CollateralWei:         big.NewInt(1000000),
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		ValidatorIndex:        20,
 		ValidatorKey:          "0xc",
 		ValidatorProposedBlocks: []Block{
@@ -1069,7 +1069,7 @@ func Test_SaveLoadFromToFile_PopulatedState(t *testing.T) {
 		AccumulatedRewardsWei: big.NewInt(53000),
 		PendingRewardsWei:     big.NewInt(000),
 		CollateralWei:         big.NewInt(4000000),
-		DepositAddress:        "0xa000000000000000000000000000000000000000",
+		WithdrawalAddress:     "0xa000000000000000000000000000000000000000",
 		ValidatorIndex:        30,
 		ValidatorKey:          "0xc",
 		// Empty Proposed blocks
@@ -1205,7 +1205,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(1000000), // Enough
 					BlockNumber:    0,
 					TxHash:         "0xab",
-					DepositAddress: "0xac",
+					WithdrawalAddress: "0xac",
 				},
 				{
 					ValidatorIndex: 2,
@@ -1213,7 +1213,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(1000000), // Enough
 					BlockNumber:    0,
 					TxHash:         "0xbb",
-					DepositAddress: "0xbc",
+					WithdrawalAddress: "0xbc",
 				},
 				{
 					ValidatorIndex: 3,
@@ -1221,7 +1221,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(50), // Not enough
 					BlockNumber:    0,
 					TxHash:         "0xbb",
-					DepositAddress: "0xbc",
+					WithdrawalAddress: "0xbc",
 				},
 			}
 			state.HandleManualSubscriptions(cfg.CollateralInWei, subs)
@@ -1256,7 +1256,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(5000000), // Too much + already subscribed
 					BlockNumber:    5,
 					TxHash:         "0xab",
-					DepositAddress: "0xac",
+					WithdrawalAddress: "0xac",
 				},
 				{
 					ValidatorIndex: 2,
@@ -1264,7 +1264,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(5000000), // Too much + already subscribed
 					BlockNumber:    5,
 					TxHash:         "0xbb",
-					DepositAddress: "0xbc",
+					WithdrawalAddress: "0xbc",
 				},
 			}
 
@@ -1295,7 +1295,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(1000070), // More than enough
 					BlockNumber:    0,
 					TxHash:         "0xcb",
-					DepositAddress: "0xcc",
+					WithdrawalAddress: "0xcc",
 				},
 			}
 			state.HandleManualSubscriptions(cfg.CollateralInWei, subs3)
@@ -1345,7 +1345,7 @@ func Test_Handle_Subscriptions_1(t *testing.T) {
 					Collateral:     big.NewInt(2500000), // More than enough
 					BlockNumber:    0,
 					TxHash:         "0xcb",
-					DepositAddress: "0xcc",
+					WithdrawalAddress: "0xcc",
 				},
 			}
 			state.HandleManualSubscriptions(cfg.CollateralInWei, subs4)
@@ -1379,7 +1379,7 @@ func Test_Handle_TODO(t *testing.T) {
 					Collateral:     big.NewInt(1000000), // Enough
 					BlockNumber:    0,
 					TxHash:         "0xab",
-					DepositAddress: "0xac",
+					WithdrawalAddress: "0xac",
 				},
 				{
 					ValidatorIndex: 20,
@@ -1387,7 +1387,7 @@ func Test_Handle_TODO(t *testing.T) {
 					Collateral:     big.NewInt(1000000), // Enough
 					BlockNumber:    0,
 					TxHash:         "0xbb",
-					DepositAddress: "0xbc",
+					WithdrawalAddress: "0xbc",
 				},
 				{
 					ValidatorIndex: 30,
@@ -1395,7 +1395,7 @@ func Test_Handle_TODO(t *testing.T) {
 					Collateral:     big.NewInt(50), // Not enough
 					BlockNumber:    0,
 					TxHash:         "0xbb",
-					DepositAddress: "0xbc",
+					WithdrawalAddress: "0xbc",
 				},
 			}
 			state.HandleManualSubscriptions(cfg.CollateralInWei, subs)
@@ -1407,7 +1407,7 @@ func Test_Handle_TODO(t *testing.T) {
 				ValidatorKey:   "0x",
 				Reward:         big.NewInt(50000000),
 				RewardType:     VanilaBlock,
-				DepositAddress: "0ac",
+				WithdrawalAddress: "0ac",
 			}
 			state.HandleCorrectBlockProposal(block1)
 
@@ -1418,7 +1418,7 @@ func Test_Handle_TODO(t *testing.T) {
 				ValidatorKey:   "0x",
 				Reward:         big.NewInt(3333333),
 				RewardType:     VanilaBlock,
-				DepositAddress: "0ac",
+				WithdrawalAddress: "0ac",
 			}
 			state.HandleCorrectBlockProposal(block2)
 


### PR DESCRIPTION
* Rename deposit to withdrawal as deposit addresses are no longer used and deprecated in favour of withdrawal.