### PR TITLE
fix: corrupted state when key was provided

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,35 +1,31 @@
 package config
 
 import (
-	"crypto/ecdsa"
 	"errors"
 	"flag"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hako/durafmt"
 	log "github.com/sirupsen/logrus"
 )
 
 type Config struct {
-	ConsensusEndpoint     string            `json:"consensus_endpoint"`
-	ExecutionEndpoint     string            `json:"execution_endpoint"`
-	Network               string            `json:"network"`
-	PoolAddress           string            `json:"pool_address"`
-	DeployedSlot          uint64            `json:"deployed_slot"`
-	CheckPointSizeInSlots uint64            `json:"checkpoint_size"`
-	PoolFeesPercent       int               `json:"pool_fees_percent"`
-	PoolFeesAddress       string            `json:"pool_fees_address"`
-	DryRun                bool              `json:"dry_run"`
-	NumRetries            int               `json:"num_retries"`
-	CollateralInWei       *big.Int          `json:"collateral_in_wei"`
-	UpdaterAddress        string            `json:"updater_address"`
-	UpdaterKeyPath        string            `json:"-"`
-	UpdaterKey            *ecdsa.PrivateKey `json:"-"`
+	ConsensusEndpoint     string   `json:"consensus_endpoint"`
+	ExecutionEndpoint     string   `json:"execution_endpoint"`
+	Network               string   `json:"network"`
+	PoolAddress           string   `json:"pool_address"`
+	DeployedSlot          uint64   `json:"deployed_slot"`
+	CheckPointSizeInSlots uint64   `json:"checkpoint_size"`
+	PoolFeesPercent       int      `json:"pool_fees_percent"`
+	PoolFeesAddress       string   `json:"pool_fees_address"`
+	DryRun                bool     `json:"dry_run"`
+	NumRetries            int      `json:"num_retries"`
+	CollateralInWei       *big.Int `json:"collateral_in_wei"`
+	UpdaterKeyPass        string   `json:"-"`
+	UpdaterKeyPath        string   `json:"-"`
 }
 
 // By default the release is a custom build. CI takes care of upgrading it with
@@ -126,26 +122,6 @@ func NewCliConfig() (*Config, error) {
 		return nil, errors.New("you can't provide a password for the keystore file in dry run mode")
 	}
 
-	// Check deployerPrivateKey is valid
-	var privateKey *ecdsa.PrivateKey
-	var publicKey string
-
-	// Only parse it not in dry run mode
-	if !*dryRun {
-		jsonBytes, err := ioutil.ReadFile(*updaterKeystorePath)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		account, err := keystore.DecryptKey(jsonBytes, *updaterKeystorePass)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		privateKey = account.PrivateKey
-		publicKey = account.Address.String()
-	}
-
 	if !common.IsHexAddress(*poolAddress) {
 		return nil, errors.New("pool-address: " + *poolAddress + " is not a valid address")
 	}
@@ -171,8 +147,7 @@ func NewCliConfig() (*Config, error) {
 		CollateralInWei:       ethCollateralInWei,
 		DryRun:                *dryRun,
 		NumRetries:            *numRetries,
-		UpdaterAddress:        publicKey,
-		UpdaterKey:            privateKey,
+		UpdaterKeyPass:        *updaterKeystorePass,
 		UpdaterKeyPath:        *updaterKeystorePath,
 	}
 	logConfig(conf)
@@ -187,7 +162,6 @@ func logConfig(cfg *Config) {
 		"PoolAddress":           cfg.PoolAddress,
 		"DeployedSlot":          cfg.DeployedSlot,
 		"CheckPointSizeInSlots": cfg.CheckPointSizeInSlots,
-		"UpdaterAddress":        cfg.UpdaterAddress,
 		"UpdaterKeyPath":        cfg.UpdaterKeyPath,
 		"PoolFeesPercent":       cfg.PoolFeesPercent,
 		"PoolFeesAddress":       cfg.PoolFeesAddress,
@@ -203,7 +177,6 @@ func logConfig(cfg *Config) {
 	if cfg.DryRun {
 		log.Warn("The pool contract will NOT be updated, running in dry-run mode")
 	} else {
-		log.Warn("Configured address to update the pool merkle root (ensure it has permissions): ", cfg.UpdaterAddress)
 		log.Info("The merkle root onchain will be updated every ", cfg.CheckPointSizeInSlots, " slots (", SlotsToTime(cfg.CheckPointSizeInSlots), ")")
 	}
 }

--- a/oracle/onchain_test.go
+++ b/oracle/onchain_test.go
@@ -22,11 +22,11 @@ import (
 // Fetches the balance of a given address
 func Test_FetchFromExecution(t *testing.T) {
 	t.Skip("Skipping test")
-	var cfgOnchain = config.Config{
+	var cfgOnchain = &config.Config{
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	onChain, err := NewOnchain(cfgOnchain)
+	onChain, err := NewOnchain(cfgOnchain, nil)
 	require.NoError(t, err)
 	account := common.HexToAddress("0xf573d99385c05c23b24ed33de616ad16a43a0919")
 	balance, err := onChain.ExecutionClient.BalanceAt(context.Background(), account, nil)
@@ -40,11 +40,11 @@ func Test_FetchFromExecution(t *testing.T) {
 func Test_GetBellatrixBlockAtSlot(t *testing.T) {
 	t.Skip("Skipping test")
 
-	var cfgOnchain = config.Config{
+	var cfgOnchain = &config.Config{
 		ConsensusEndpoint: "http://127.0.0.1:5051",
 		ExecutionEndpoint: "http://127.0.0.1:8545",
 	}
-	onchain, err := NewOnchain(cfgOnchain)
+	onchain, err := NewOnchain(cfgOnchain, nil)
 	require.NoError(t, err)
 	folder := "../mock"
 	blockType := "capella"

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -102,7 +102,6 @@ func Test_100_slots_test(t *testing.T) {
 	oracle := NewOracle(&config.Config{
 		Network:               "mainnet",
 		PoolAddress:           "0xdead000000000000000000000000000000000000",
-		UpdaterAddress:        "",
 		DeployedSlot:          uint64(50000),
 		CheckPointSizeInSlots: uint64(100),
 		PoolFeesPercent:       5,

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -188,7 +188,7 @@ func (state *OracleState) SaveStateToFile() {
 	}
 	file, err := os.Create(path)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("could not create file at path: ", path, ":", err)
 	}
 
 	defer file.Close()
@@ -207,7 +207,11 @@ func (state *OracleState) SaveStateToFile() {
 		//"MerkleRoot":      mRoot,
 		//"EnoughData":      enoughData,
 	}).Info("Saving state to file")
-	encoder.Encode(state)
+
+	err = encoder.Encode(state)
+	if err != nil {
+		log.Fatal("could not encode state into file: ", err)
+	}
 }
 
 func (state *OracleState) LoadStateFromFile() error {


### PR DESCRIPTION
* Due to a missing error check, the state was not being stored correctly when providing keys to update the contract.
* It was silently failing and not storing locally the state. This caused that when the oracle restarted, it couldnt load the old state, requiring to sync from th begining.