### PR TITLE
Dont update state if behind onchain root

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -908,14 +908,12 @@ func (m *ApiService) GetSubscriptionsTillHead(latestProcessedBlock uint64) ([]or
 	}
 
 	// Loop over all found events. Super inneficient. just Proof of concept
-	// TODO: When finished add a test in api_test for this feature, since its api specific.
 	blockSubscriptions := make([]oracle.Subscription, 0)
 	for itrSubs.Next() {
 		sub := oracle.Subscription{
 			Event:     itrSubs.Event,
 			Validator: m.Onchain.Validators()[phase0.ValidatorIndex(itrSubs.Event.ValidatorID)],
 		}
-		log.Info("block sub finalized until latest head: ", sub)
 		blockSubscriptions = append(blockSubscriptions, sub)
 	}
 	err = itrSubs.Close()
@@ -941,7 +939,6 @@ func (m *ApiService) GetUnsubscriptionsTillHead(latestProcessedBlock uint64) ([]
 			Event:     itrUnsubs.Event,
 			Validator: m.Onchain.Validators()[phase0.ValidatorIndex(itrUnsubs.Event.ValidatorID)],
 		}
-		log.Info("block unsub finalized until latest head: ", unsub)
 		blockUnsubscriptions = append(blockUnsubscriptions, unsub)
 	}
 	err = itrUnsubs.Close()

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -607,6 +607,11 @@ func (o *Onchain) GetAllBlockInfo(slot uint64) (Block, []Subscription, []Unsubsc
 
 func (o *Onchain) UpdateContractMerkleRoot(newMerkleRoot string) string {
 
+	// Support both 0x prefixed and non prefixed merkle roots
+	if strings.HasPrefix(newMerkleRoot, "0x") {
+		newMerkleRoot = newMerkleRoot[2:]
+	}
+
 	// Parse merkle root to byte array
 	newMerkleRootBytes := [32]byte{}
 	unboundedBytes := common.Hex2Bytes(newMerkleRoot)

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -30,6 +30,9 @@ type ValidatorStatus uint8
 type Event uint8
 type BlockType uint8
 
+const DefaultRoot = "0x0000000000000000000000000000000000000000000000000000000000000000"
+const DefaultAddress = "0x0000000000000000000000000000000000000000"
+
 // TODO: Dont export functions and variables that are not used outside the package
 
 // Types of block rewards
@@ -180,6 +183,15 @@ func NewOracleState(cfg *config.Config) *OracleState {
 		MissedBlocks:    make([]Block, 0),
 		WrongFeeBlocks:  make([]Block, 0),
 		Config:          cfg,
+		LatestCommitedState: OnchainState{
+			Validators: make(map[uint64]*ValidatorInfo, 0),
+			Slot:       0,
+			TxHash:     "",
+			MerkleRoot: DefaultRoot,
+			Tree:       nil,
+			Proofs:     make(map[string][]string, 0),
+			Leafs:      make(map[string]RawLeaf, 0),
+		},
 	}
 }
 
@@ -313,7 +325,7 @@ func (state *OracleState) StoreLatestOnchainState() bool {
 	if !enoughData {
 		return false
 	}
-	merkleRootStr := hex.EncodeToString(tree.Root)
+	merkleRootStr := "0x" + hex.EncodeToString(tree.Root)
 
 	log.WithFields(log.Fields{
 		"LatestProcessedSlot": state.LatestProcessedSlot,
@@ -957,7 +969,7 @@ func (state *OracleState) GetMerkleRootIfAny() (string, bool) {
 	if !enoughData {
 		return "", enoughData
 	}
-	merkleRootStr := hex.EncodeToString(tree.Root)
+	merkleRootStr := "0x" + hex.EncodeToString(tree.Root)
 
 	return merkleRootStr, true
 }


### PR DESCRIPTION
* If an oracle loses its local state, it must use the existing onchain root to ensure it doesnt update old roots. If this happens, the oracle would be updating the contract with old roots, so it must keep track on the latest known state onchain, and only update the state once it has reached this one.
* This would be very rare to happen, but can happen if the oracle loses its local state.
* This is solved by only allowing the oracle to update the root once it has been able to reconstruct the latest existing onchain, meaning that "its on the same page".