### PR TITLE
Add small log fixes

### DIFF
--- a/oracle/block.go
+++ b/oracle/block.go
@@ -62,14 +62,14 @@ func (b *VersionedSignedBeaconBlock) MevRewardInWei(poolAddress string) (*big.In
 			if strings.ToLower(b.GetFeeRecipient()) == strings.ToLower(msg.From().String()) {
 				totalMevReward.Add(totalMevReward, msg.Value())
 				log.WithFields(log.Fields{
-					"Slot":         b.GetSlot(),
-					"Block":        b.GetBlockNumber(),
-					"ValIndex":     b.GetProposerIndex(),
-					"FeeRecipient": b.GetFeeRecipient()[0:4],
-					"To":           msg.To().String(),
-					"Reward":       msg.Value(),
-					"TxHash":       tx.Hash().String()[0:4],
-					"Type":         "MevBlock",
+					"Slot":            b.GetSlot(),
+					"Block":           b.GetBlockNumber(),
+					"ValIndex":        b.GetProposerIndex(),
+					"FeeRecipient":    b.GetFeeRecipient(),
+					"MEVFeeRecipient": msg.To().String(),
+					"Reward":          msg.Value(),
+					"TxHash":          tx.Hash().String(),
+					"Type":            "MevBlock",
 				}).Info("[Reward]")
 				numTxs++
 			}

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -813,7 +813,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalOk",
 				"StateChange":    "Active -> Active",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Active
 		case ProposalWrongFee:
@@ -821,7 +821,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalWrongFee",
 				"StateChange":    "Active -> Banned",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Banned
 		case ProposalMissed:
@@ -829,7 +829,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalMissed",
 				"StateChange":    "Active -> YellowCard",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = YellowCard
 		case Unsubscribe:
@@ -837,7 +837,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "Unsubscribe",
 				"StateChange":    "Active -> NotSubscribed",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = NotSubscribed
 		}
@@ -848,7 +848,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalOk",
 				"StateChange":    "YellowCard -> Active",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Active
 		case ProposalWrongFee:
@@ -856,7 +856,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalWrongFee",
 				"StateChange":    "YellowCard -> Banned",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Banned
 		case ProposalMissed:
@@ -864,7 +864,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalMissed",
 				"StateChange":    "YellowCard -> RedCard",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = RedCard
 		case Unsubscribe:
@@ -872,7 +872,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "Unsubscribe",
 				"StateChange":    "YellowCard -> NotSubscribed",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = NotSubscribed
 		}
@@ -883,7 +883,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalOk",
 				"StateChange":    "RedCard -> YellowCard",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = YellowCard
 		case ProposalWrongFee:
@@ -891,7 +891,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalWrongFee",
 				"StateChange":    "RedCard -> Banned",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Banned
 		case ProposalMissed:
@@ -899,7 +899,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ProposalMissed",
 				"StateChange":    "RedCard -> RedCard",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = RedCard
 		case Unsubscribe:
@@ -907,7 +907,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "Unsubscribe",
 				"StateChange":    "RedCard -> NotSubscribed",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = NotSubscribed
 		}
@@ -918,7 +918,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "ManualSubscription",
 				"StateChange":    "NotSubscribed -> Active",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Active
 		case AutoSubscription:
@@ -926,7 +926,7 @@ func (state *OracleState) AdvanceStateMachine(valIndex uint64, event Event) {
 				"Event":          "AutoSubscription",
 				"StateChange":    "NotSubscribed -> Active",
 				"ValidatorIndex": valIndex,
-				"ProcessedSlot":  state.LatestProcessedSlot,
+				"Slot":           state.NextSlotToProcess,
 			}).Info("Validator state change")
 			state.Validators[valIndex].ValidatorStatus = Active
 		}


### PR DESCRIPTION
In MevBlocks:
- Print the full values of FeeRecipient and TxHash, rather than just the first four characters.
- Rename the "To" field as "MEVFeeRecipient", since its the address that is recieving the MEV reward. Should be always the smoothing pool contract address

For logging changes in the oracle state:

- Previously, the printed slot was one behind the correct one, because it used LatestProcessedSlot.
- Update to use NextSlotToProcess (LatestProcessedSlot + 1), which reflects the slot the oracle state is changing to.

