### PR TITLE
add mutex & fix some logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	if err == nil {
 		log.Info("Found previous state to continue syncing")
 	} else {
-		log.Info("Previous state not found or could not be loaded, syncing from the begining: ", err)
+		log.Warn("Previous state not found or could not be loaded, syncing from the begining: ", err)
 	}
 
 	api := api.NewApiService(cfg, oracleInstance, onchain)
@@ -115,11 +115,12 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *confi
 		log.Info("Latest known root by oracle does not match the latest onchain. ",
 			latestOnchainRoot, " ", latestKnownRoot)
 		log.Info("The state wont be updated until the same root is reached")
+	} else if cfg.DryRun {
+		log.Info("Latest known root by oracle matches the latest on-chain root, but dry run mode is enabled. The onchain root wont be updated")
 	} else {
 		syncedWithOnchainRoot = true
-		log.Info("Latest known root by oracle matches the latest onchain, oracle is ready to update new roots")
+		log.Info("Latest known root by oracle matches the latest on-chain root. Oracle is ready to update new roots.")
 	}
-
 	// Load all the validators from the beacon chain
 	onchain.RefreshBeaconValidators()
 

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -3,6 +3,7 @@ package oracle
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/dappnode/mev-sp-oracle/config"
 	log "github.com/sirupsen/logrus"
@@ -11,6 +12,7 @@ import (
 type Oracle struct {
 	cfg   *config.Config
 	State *OracleState
+	mu sync.RWMutex
 }
 
 func NewOracle(cfg *config.Config) *Oracle {
@@ -33,6 +35,10 @@ func (or *Oracle) AdvanceStateToNextSlot(
 	blockUnsubs []Unsubscription,
 	blockDonations []Donation) (uint64, error) {
 
+	//declare mutex and release it when function returns
+	or.mu.Lock()
+	defer or.mu.Unlock()
+	
 	if or.State.NextSlotToProcess != (or.State.LatestProcessedSlot + 1) {
 		log.Fatal("Next slot to process is not the last processed slot + 1",
 			or.State.NextSlotToProcess, " ", or.State.LatestProcessedSlot)


### PR DESCRIPTION
- Add mutex "mu sync.RWMutex" in the Oracle struct so that AdvanceStateToNextSlot() can use it and does not initialize a new mutex each time. Mutex mu is unlocked when AdvanceStateToNextSlot() returns
- Fixed/refactored some logs (warning when no state loaded & check if dryrun is enabled before printing that oracle is ready to commit new roots to onchain)