### PR TITLE
Add mutex and misc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ deployments/postgres-data
 deployments/metabase-data
 deployments/.env
 state.gob
+state_unused.gob

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/dappnode/mev-sp-oracle/api"
 	"github.com/dappnode/mev-sp-oracle/config"
 	"github.com/dappnode/mev-sp-oracle/oracle"
@@ -100,24 +99,6 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *confi
 	// losing sync, restarting and updating the roots again with old ones.
 	syncedWithOnchainRoot := false
 
-	latestKnownRoot := oracleInstance.State().LatestCommitedState.MerkleRoot
-
-	log.Info("Latest known commited merkle root: ", latestKnownRoot)
-	latestOnchainRoot, err := onchain.GetContractMerkleRoot()
-	if err != nil {
-		log.Fatal("Could not get contract merkle root: ", err)
-	}
-	log.Info("Latest onchain commited merkle root: ", latestOnchainRoot)
-
-	if !oracle.Equals(latestKnownRoot, latestOnchainRoot) {
-		log.Info("Latest known root by oracle does not match the latest onchain. ",
-			latestOnchainRoot, " ", latestKnownRoot)
-		log.Info("The state wont be updated until the same root is reached")
-	} else {
-		syncedWithOnchainRoot = true
-		log.Info("Latest known root by oracle matches the latest onchain, oracle is ready to update new roots")
-	}
-
 	// Load all the validators from the beacon chain
 	onchain.RefreshBeaconValidators()
 
@@ -179,42 +160,67 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *confi
 			continue
 		}
 
-		// 1200 slots is 4 hour
-		UpdateValidatorsIntervalSlots := uint64(1200)
+		// 600 slots is 2 hours
+		UpdateValidatorsIntervalSlots := uint64(600)
 		if oracleInstance.State().LatestProcessedSlot%UpdateValidatorsIntervalSlots == 0 {
-			validators := onchain.Validators()
-			lastValidator := validators[phase0.ValidatorIndex(len(validators)-1)]
-
-			// Update only if the oracle advances beyond the last validator we have
-			if lastValidator.Validator.ActivationEligibilityEpoch <= phase0.Epoch(oracleInstance.State().LatestProcessedSlot/SlotsInEpoch) {
-				onchain.RefreshBeaconValidators()
-			}
+			onchain.RefreshBeaconValidators()
 		}
 
 		// Every CheckPointSizeInSlots we commit the state
 		if oracleInstance.State().LatestProcessedSlot%cfg.CheckPointSizeInSlots == 0 {
 			log.Info("Checkpoint reached, latest processed slot: ", oracleInstance.State().LatestProcessedSlot)
 
-			// mRoot, enoughData := oracle.State.GetMerkleRootIfAny()
-			enoughData := oracleInstance.StoreLatestOnchainState()
-
-			oracleInstance.State().SaveStateToFile()
-
+			// Get the latest onchain root (from the contract)
 			latestOnchainRoot, err := onchain.GetContractMerkleRoot()
 			if err != nil {
-				log.Fatal("Could not get contract merkle root: ", err)
+				log.Fatal("Could not get latest onchain root: ", err)
 			}
+
+			// Get the latest calculated root (from the oracle)
+			prevOracleRoot := oracleInstance.State().LatestCommitedState.MerkleRoot
+
+			// Ensure we didnt fell behind sync. If we did, we wont update the contract
+			if !oracle.Equals(latestOnchainRoot, prevOracleRoot) {
+				syncedWithOnchainRoot = false
+				log.WithFields(log.Fields{
+					"LatestOnChainRoot": latestOnchainRoot,
+					"NewCalculateRoot":  prevOracleRoot,
+					"RootSlot":          oracleInstance.State().LatestCommitedState.Slot,
+				}).Info("Oracle IS NOT in sync with the latest onchain root")
+			} else {
+				syncedWithOnchainRoot = true
+				log.WithFields(log.Fields{
+					"LatestOnChainRoot": latestOnchainRoot,
+					"NewCalculateRoot":  prevOracleRoot,
+					"RootSlot":          oracleInstance.State().LatestCommitedState.Slot,
+				}).Info("Oracle IS in sync with the latest onchain root")
+			}
+
+			// Calculate new state with new root
+			enoughData := oracleInstance.StoreLatestOnchainState()
 			newOracleRoot := oracleInstance.State().LatestCommitedState.MerkleRoot
 
-			// Every time we calculate a new root, see if it matches the latest one onchain.
-			// If it does, we are in sync with the onchain root and we can update the contract.
-			if oracle.Equals(latestOnchainRoot, newOracleRoot) {
+			// Persist new state in file
+			oracleInstance.State().SaveStateToFile()
+
+			// If we were not in sync and the new root matches the latest onchain root, we are now in sync
+			// meaning that in the next checkpoint we will update the contract
+			if !syncedWithOnchainRoot && oracle.Equals(latestOnchainRoot, newOracleRoot) {
 				syncedWithOnchainRoot = true
-				log.Info("Latest known root by oracle matches the latest onchain root: ",
-					latestOnchainRoot, " ", newOracleRoot)
-			} else {
-				log.Info("New merkle root calculated, but it does not match the latest onchain root. Continue syncing until we reach the same root ",
-					latestOnchainRoot, " ", newOracleRoot)
+				log.WithFields(log.Fields{
+					"LatestOnChainRoot": latestOnchainRoot,
+					"NewCalculateRoot":  newOracleRoot,
+					"RootSlot":          oracleInstance.State().LatestCommitedState.Slot,
+				}).Info("New oracle root IS in sync with the latest onchain root")
+			}
+
+			// If we were not in sync and the new roots doesnt match, just log the progress
+			if !syncedWithOnchainRoot && !oracle.Equals(latestOnchainRoot, newOracleRoot) {
+				log.WithFields(log.Fields{
+					"LatestOnChainRoot": latestOnchainRoot,
+					"NewCalculateRoot":  newOracleRoot,
+					"RootSlot":          oracleInstance.State().LatestCommitedState.Slot,
+				}).Info("New oracle root IS NOT in sync with the latest onchain root")
 			}
 
 			if !enoughData {

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -716,13 +716,21 @@ func (o *Onchain) UpdateContractMerkleRoot(newMerkleRoot string) string {
 
 // Loads all validator from the beacon chain into the oracle, must be called periodically
 func (o *Onchain) RefreshBeaconValidators() {
-	log.Info("Loading existing validators in the beacon chain")
+	log.Info("Loading existing validators from the beacon chain")
 	vals, err := o.GetFinalizedValidators()
 	if err != nil {
 		log.Fatal("Could not get validators: ", err)
 	}
 	o.validators = vals
-	log.Info("Done loading existing validators in the beacon chain total: ", len(vals))
+	if len(vals) != 0 {
+		log.WithFields(log.Fields{
+			"TotalValidators":       len(vals),
+			"LastIndex":             vals[phase0.ValidatorIndex(len(vals)-1)].Index,
+			"ActivationSlotLastVal": GetActivationSlotOfLatestProcessedValidator(vals),
+		}).Info("Done loading beacon chain validators")
+	} else {
+		log.Fatal("No validators were loaded from the beacon chain")
+	}
 }
 
 func (o *Onchain) Validators() map[phase0.ValidatorIndex]*v1.Validator {

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -3,6 +3,7 @@ package oracle
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/dappnode/mev-sp-oracle/config"
 	log "github.com/sirupsen/logrus"
@@ -10,7 +11,8 @@ import (
 
 type Oracle struct {
 	cfg   *config.Config
-	State *OracleState
+	state *OracleState
+	mutex sync.RWMutex
 }
 
 func NewOracle(cfg *config.Config) *Oracle {
@@ -18,10 +20,16 @@ func NewOracle(cfg *config.Config) *Oracle {
 
 	oracle := &Oracle{
 		cfg:   cfg,
-		State: state,
+		state: state,
 	}
 
 	return oracle
+}
+
+func (or *Oracle) State() *OracleState {
+	or.mutex.RLock()
+	defer or.mutex.RUnlock()
+	return or.state
 }
 
 // Advances the oracle to the next state, processing LatestSlot proposals/donations
@@ -33,9 +41,12 @@ func (or *Oracle) AdvanceStateToNextSlot(
 	blockUnsubs []Unsubscription,
 	blockDonations []Donation) (uint64, error) {
 
-	if or.State.NextSlotToProcess != (or.State.LatestProcessedSlot + 1) {
+	or.mutex.Lock()
+	defer or.mutex.Unlock()
+
+	if or.state.NextSlotToProcess != (or.state.LatestProcessedSlot + 1) {
 		log.Fatal("Next slot to process is not the last processed slot + 1",
-			or.State.NextSlotToProcess, " ", or.State.LatestProcessedSlot)
+			or.state.NextSlotToProcess, " ", or.state.LatestProcessedSlot)
 	}
 
 	err := or.validateParameters(blockPool, blockSubs, blockUnsubs, blockDonations)
@@ -44,11 +55,11 @@ func (or *Oracle) AdvanceStateToNextSlot(
 	}
 
 	// Handle subscriptions first thing
-	or.State.HandleManualSubscriptions(blockSubs)
+	or.state.HandleManualSubscriptions(blockSubs)
 
 	// If the validator was subscribed and missed proposed the block in this slot
-	if blockPool.BlockType == MissedProposal && or.State.IsSubscribed(blockPool.ValidatorIndex) {
-		or.State.HandleMissedBlock(blockPool)
+	if blockPool.BlockType == MissedProposal && or.state.IsSubscribed(blockPool.ValidatorIndex) {
+		or.state.HandleMissedBlock(blockPool)
 	}
 
 	// If a block was proposed in the slot (not missed)
@@ -57,34 +68,41 @@ func (or *Oracle) AdvanceStateToNextSlot(
 		if blockPool.BlockType == OkPoolProposalBlsKeys {
 			// TODO: This is a bit hackish
 			log.Warn("Block proposal was ok but bls keys are not supported, sending rewards to pool")
-			or.State.SendRewardToPool(blockPool.Reward)
+			or.state.SendRewardToPool(blockPool.Reward)
 			// TODO: Send rewards to pool as we dont know any validator address to give it
 		}
 
 		// Manual subscription. If feeRec is ok, means the reward was sent to the pool
 		if blockPool.BlockType == OkPoolProposal {
-			or.State.HandleCorrectBlockProposal(blockPool)
+			or.state.HandleCorrectBlockProposal(blockPool)
 		}
 		// If the validator was subscribed but the fee recipient was wrong
 		// we ban the validator as it is not following the protocol rules
-		if blockPool.BlockType == WrongFeeRecipient && or.State.IsSubscribed(blockPool.ValidatorIndex) {
-			or.State.HandleBanValidator(blockPool)
+		if blockPool.BlockType == WrongFeeRecipient && or.state.IsSubscribed(blockPool.ValidatorIndex) {
+			or.state.HandleBanValidator(blockPool)
 		}
 	}
 
 	// Handle unsubscriptions the last thing after distributing rewards
-	or.State.HandleManualUnsubscriptions(blockUnsubs)
+	or.state.HandleManualUnsubscriptions(blockUnsubs)
 
 	// Handle the donations from this block
-	or.State.HandleDonations(blockDonations)
+	or.state.HandleDonations(blockDonations)
 
-	processedSlot := or.State.NextSlotToProcess
-	or.State.LatestProcessedSlot = processedSlot
-	or.State.NextSlotToProcess++
+	processedSlot := or.state.NextSlotToProcess
+	or.state.LatestProcessedSlot = processedSlot
+	or.state.NextSlotToProcess++
 	if blockPool.BlockType != MissedProposal {
-		or.State.LatestProcessedBlock = blockPool.Block
+		or.state.LatestProcessedBlock = blockPool.Block
 	}
 	return processedSlot, nil
+}
+
+func (or *Oracle) StoreLatestOnchainState() bool {
+	or.mutex.Lock()
+	defer or.mutex.Unlock()
+
+	return or.state.StoreLatestOnchainState()
 }
 
 func (or *Oracle) validateParameters(
@@ -93,9 +111,9 @@ func (or *Oracle) validateParameters(
 	blockUnsubs []Unsubscription,
 	blockDonations []Donation) error {
 
-	if blockPool.Slot != or.State.NextSlotToProcess {
+	if blockPool.Slot != or.state.NextSlotToProcess {
 		return errors.New(fmt.Sprint("Slot of blockPool is not the same as the latest slot of the oracle. BlockPool: ",
-			blockPool.Slot, " Oracle: ", or.State.NextSlotToProcess))
+			blockPool.Slot, " Oracle: ", or.state.NextSlotToProcess))
 	}
 
 	// TODO: Add more validators to block subs unsubs, donations, etc

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -246,11 +246,11 @@ func Test_100_slots_test(t *testing.T) {
 
 	// What we owe
 	totalLiabilities := big.NewInt(0)
-	for _, val := range oracle.State.Validators {
+	for _, val := range oracle.State().Validators {
 		totalLiabilities.Add(totalLiabilities, val.AccumulatedRewardsWei)
 		totalLiabilities.Add(totalLiabilities, val.PendingRewardsWei)
 	}
-	totalLiabilities.Add(totalLiabilities, oracle.State.PoolAccumulatedFees) // TODO: rename wei
+	totalLiabilities.Add(totalLiabilities, oracle.State().PoolAccumulatedFees) // TODO: rename wei
 
 	require.Equal(t, totalAssets, totalLiabilities)
 }

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -325,8 +325,8 @@ func (state *OracleState) StoreLatestOnchainState() bool {
 	merkleRootStr := "0x" + hex.EncodeToString(tree.Root)
 
 	log.WithFields(log.Fields{
-		"LatestProcessedSlot": state.LatestProcessedSlot,
-		"MerkleRoot":          merkleRootStr,
+		"Slot":       state.LatestProcessedSlot,
+		"MerkleRoot": merkleRootStr,
 	}).Info("Freezing state")
 
 	// Merkle proofs for each withdrawal address

--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -313,11 +313,8 @@ func (state *OracleState) LoadStateFromFile() error {
 // Returns false if there wasnt enough data to create a merkle tree
 func (state *OracleState) StoreLatestOnchainState() bool {
 
-	// Quick way of coping the whole state
 	validatorsCopy := make(map[uint64]*ValidatorInfo)
-	for k2, v2 := range state.Validators {
-		validatorsCopy[k2] = v2
-	}
+	DeepCopy(state.Validators, &validatorsCopy)
 
 	mk := NewMerklelizer()
 	// TODO: returning orderedRawLeafs as a quick workaround to get the proofs

--- a/oracle/utils.go
+++ b/oracle/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/dappnode/mev-sp-oracle/config"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -210,4 +211,34 @@ func DeepCopy(a, b interface{}) {
 	dec := gob.NewDecoder(buff)
 	enc.Encode(a)
 	dec.Decode(b)
+}
+
+// TODO: unit test
+func GetActivationSlotOfLatestProcessedValidator(
+	validators map[phase0.ValidatorIndex]*v1.Validator) uint64 {
+	MaxUint := ^uint64(0)
+	if len(validators) == 0 {
+		log.Fatal("validators map is empty")
+	}
+
+	latestEpoch := uint64(0)
+
+	// Could be faster if iterated backwards
+	for _, val := range validators {
+		// When validators are not processed yet, max uint64 is stored
+		activationEpoch := uint64(val.Validator.ActivationEpoch)
+		if activationEpoch != MaxUint &&
+			activationEpoch > latestEpoch {
+			latestEpoch = activationEpoch
+		}
+	}
+
+	// Could technically happen if oracle were deployed in genesis
+	// But useful as a sanity check
+	if latestEpoch == 0 {
+		log.Fatal("latestEpoch is 0")
+	}
+
+	SlotsInEpoch := uint64(32)
+	return latestEpoch * SlotsInEpoch
 }

--- a/oracle/utils.go
+++ b/oracle/utils.go
@@ -1,6 +1,8 @@
 package oracle
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/hex"
 	"io/ioutil"
 	"math/big"
@@ -196,4 +198,16 @@ func DecryptKey(cfg *config.Config) (*keystore.Key, error) {
 		return account, nil
 	}
 	return nil, errors.New("running in dry run mode, key is not needed")
+}
+
+// TODO: Test
+// Not the most efficient way of deep coping, if performance
+// matters, dont use this.
+func DeepCopy(a, b interface{}) {
+
+	buff := new(bytes.Buffer)
+	enc := gob.NewEncoder(buff)
+	dec := gob.NewDecoder(buff)
+	enc.Encode(a)
+	dec.Decode(b)
 }


### PR DESCRIPTION
* Use a read mutex so that when the oracle is interrupted and the state is stored onchain, we don't get an intermediate state of the oracle. The read mutex is locked until the whole block has been processed.
* Lock a write mutex in advatance oracle state function.
* Reuse the mutex all over the code, also in the api to prevent race conditions, which are less critical but still.
* Fix issue where the onchain validators were not deepcopied (just a reference)
* Reload validators from beacon chain more often
* Fix bug when updating merkle roots, minor mainly logs.