### PR TITLE
Store on OracleState all commited states + test ValidatorInfo size

### DIFF
--- a/oracle/oraclestate.go
+++ b/oracle/oraclestate.go
@@ -154,7 +154,9 @@ type OracleState struct {
 	Network              string
 	PoolAddress          string
 	Validators           map[uint64]*ValidatorInfo
-	LatestCommitedState  OnchainState
+
+	LatestCommitedState OnchainState
+	CommitedStates      map[string]OnchainState
 
 	PoolFeesPercent     int
 	PoolFeesAddress     string
@@ -200,6 +202,7 @@ func NewOracleState(cfg *config.Config) *OracleState {
 			Proofs:     make(map[string][]string, 0),
 			Leafs:      make(map[string]RawLeaf, 0),
 		},
+		CommitedStates: make(map[string]OnchainState, 0),
 	}
 }
 
@@ -373,6 +376,10 @@ func (state *OracleState) StoreLatestOnchainState() bool {
 		Leafs:      leafs,
 	}
 
+	// besides the latestCommitedState as a "standalone" state,
+	// we also store it in the commitedStates map, where we keep all
+	// the states that have been commited onchain by hash
+	state.CommitedStates[merkleRootStr] = state.LatestCommitedState
 	return true
 }
 

--- a/oracle/oraclestate_test.go
+++ b/oracle/oraclestate_test.go
@@ -1737,79 +1737,84 @@ func Test_CanValidatorSubscribeToPool(t *testing.T) {
 	}), true)
 }
 
-// how much does the validator info of 2000 validators take in memory?
-// how many validators can we have in memory?
-// func Test_ValidatorInfoSize(t *testing.T) {
-// 	for i := 0; i < 3; i++ {
-// 		state := NewOracleState(&config.Config{
-// 			CollateralInWei: big.NewInt(1000),
-// 		})
+// Test to estimate how much memory the validator state will take with 2000 validators,
+// each one proposing a block
+func Test_ValidatorInfoSize(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		state := NewOracleState(&config.Config{
+			CollateralInWei: big.NewInt(1000),
+		})
 
-// 		//save state of 2000 validators
-// 		numValidators := 2000
+		//save state of 2000 validators
+		numValidators := 2000
 
-// 		//create 2000 validators with index 0-1999
-// 		valsID := make([]uint64, numValidators)
-// 		for i := 0; i < numValidators; i++ {
-// 			valsID[i] = uint64(i)
-// 		}
-// 		//subscribe 2000 validators
-// 		subs := new_subs_slice(common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"), valsID, big.NewInt(1000))
-// 		state.HandleManualSubscriptions(subs)
+		//create 2000 validators with index 0-1999
+		valsID := make([]uint64, numValidators)
+		for i := 0; i < numValidators; i++ {
+			valsID[i] = uint64(i)
+		}
+		//subscribe 2000 validators
+		subs := new_subs_slice(common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"), valsID, big.NewInt(1000))
+		state.HandleManualSubscriptions(subs)
 
-// 		//make 2000 validators propose a block
-// 		for i := 0; i < numValidators; i++ {
-// 			state.HandleCorrectBlockProposal(Block{
-// 				Slot:              uint64(100),
-// 				ValidatorIndex:    uint64(valsID[i]),
-// 				ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
-// 				Reward:            big.NewInt(5000000000000000000), // 0.5 eth of reward
-// 				RewardType:        MevBlock,
-// 				WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
-// 			})
-// 		}
+		//make 2000 validators propose a block
+		for i := 0; i < numValidators; i++ {
+			state.HandleCorrectBlockProposal(Block{
+				Slot:              uint64(i),
+				ValidatorIndex:    uint64(valsID[0]),
+				ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
+				Reward:            big.NewInt(5000000000000000000), // 0.5 eth of reward
+				RewardType:        MevBlock,
+				WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
+			})
+		}
 
-// 		// //make 2000 validators miss a block
-// 		// for i := 0; i < numValidators; i++ {
-// 		// 	state.HandleMissedBlock(Block{
-// 		// 		Slot:              uint64(100),
-// 		// 		ValidatorIndex:    uint64(valsID[i]),
-// 		// 		ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
-// 		// 		Reward:            big.NewInt(5000000000000000000),
-// 		// 		RewardType:        VanilaBlock,
-// 		// 		WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
-// 		// 	})
-// 		// }
+		// //make 2000 validators miss a block
+		// for i := 0; i < numValidators; i++ {
+		// 	state.HandleMissedBlock(Block{
+		// 		Slot:              uint64(100),
+		// 		ValidatorIndex:    uint64(valsID[i]),
+		// 		ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
+		// 		Reward:            big.NewInt(5000000000000000000),
+		// 		RewardType:        VanilaBlock,
+		// 		WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
+		// 	})
+		// }
 
-// 		// //make 2000 validators propose a block
-// 		// for i := 0; i < numValidators; i++ {
-// 		// 	state.HandleCorrectBlockProposal(Block{
-// 		// 		Slot:              uint64(100),
-// 		// 		ValidatorIndex:    uint64(valsID[i]),
-// 		// 		ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
-// 		// 		Reward:            big.NewInt(5000000000000000000), // 0.5 eth of reward
-// 		// 		RewardType:        MevBlock,
-// 		// 		WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
-// 		// 	})
-// 		// }
-// 		state.SaveStateToFile()
-// 		filePath := "oracle-data/state.gob"
+		// //make 2000 validators propose a block
+		// for i := 0; i < numValidators; i++ {
+		// 	state.HandleCorrectBlockProposal(Block{
+		// 		Slot:              uint64(100),
+		// 		ValidatorIndex:    uint64(valsID[i]),
+		// 		ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
+		// 		Reward:            big.NewInt(5000000000000000000), // 0.5 eth of reward
+		// 		RewardType:        MevBlock,
+		// 		WithdrawalAddress: "0x0123456789abcdef0123456789abcdef01234567",
+		// 	})
+		// }
+		state.SaveStateToFile()
+		filePath := "oracle-data/state.gob"
 
-// 		// Get file information
-// 		fileInfo, err := os.Stat(filePath)
-// 		if err != nil {
-// 			log.Fatal(err)
-// 		}
+		// Get file information
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-// 		// Get file size in bytes
-// 		fileSize := fileInfo.Size()
-// 		fileSizeMB := float64(fileSize) / (1024 * 1024)
+		// Get file size in bytes
+		fileSize := fileInfo.Size()
+		fileSizeMB := float64(fileSize) / (1024 * 1024)
 
-// 		// Print the file size
-// 		log.Info("File size:", fileSizeMB, "MB")
-// 	}
-// }
+		// Print the file size
+		log.Info("File size:", fileSizeMB, "MB")
+	}
+}
 
+// This test tries to mock a real time scenario where 2000 validators are tracked by the pool,
+// and tries check how much memory the oracleState takes.
+// In this scenario, the oracle uploads a new state to the chain once every 3 days.
+// Since we have 2000 validators, each time the state is uploaded to the chain,
+// a rough estimate of 100 blocks will have been proposed by the validators.
 func Test_SizeMultipleOnchainState(t *testing.T) {
 
 	state := NewOracleState(&config.Config{
@@ -1817,7 +1822,7 @@ func Test_SizeMultipleOnchainState(t *testing.T) {
 		PoolFeesAddress: "0x1123456789abcdef0123456789abcdef01234568",
 	})
 
-	//save state of 2000 validators
+	//prepare 2000 validators
 	numValidators := 2000
 
 	//create 2000 validators with index 0-1999
@@ -1825,31 +1830,16 @@ func Test_SizeMultipleOnchainState(t *testing.T) {
 	for i := 0; i < numValidators; i++ {
 		valsID[i] = uint64(i)
 	}
-	//subscribe 2000 validators
+	//subscribe 2000 validators. All validators will have the same withdrawal address.
 	subs := new_subs_slice(common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"), valsID, big.NewInt(1000))
+
+	//oracle handles the subscriptions.
 	state.HandleManualSubscriptions(subs)
 
-	//make 2000 validators propose a block
-	for i := 0; i < numValidators; i++ {
-		state.HandleCorrectBlockProposal(Block{
-			Slot:              uint64(100),
-			ValidatorIndex:    uint64(valsID[i]),
-			ValidatorKey:      "0x0123456789abcdef0123456789abcdef01234567",
-			Reward:            big.NewInt(5000000000000000000), // 0.5 eth of reward
-			RewardType:        MevBlock,
-			WithdrawalAddress: "0x0100000000000000000000009b3b13d6b6f3f52154a8b00d818392b61e4b42b4",
-		})
-	}
-
-	// the "StoreLatestOnchainState" function is responsible of making a deep copy of all
-	// current validator data and storing it in the new "state.CommitedStates" map, which
-	// contains all the past onchain states of the validators.
-	// each time we store a new latestOnchainState, the merkleroot has changed, so we
-	// store a new state of all the validators.
-	// in a year, will update the onchain state 121 times. each time we do this, we will
-	// store the last onchain state, which contains the information of all the validators
+	//simulate the scenario. In one year, we will commit 121 states to the chain.
+	//each time the state is commited, a rough estimate of 100 blocks will have been proposed by the validators.
 	for i := 0; i < 121; i++ {
-		for j := 0; j < 99; j++ {
+		for j := 0; j < 100; j++ {
 			state.HandleCorrectBlockProposal(Block{
 				Slot:              uint64(100),
 				ValidatorIndex:    uint64(valsID[j]),
@@ -1859,9 +1849,20 @@ func Test_SizeMultipleOnchainState(t *testing.T) {
 				WithdrawalAddress: "0x0100000000000000000000009b3b13d6b6f3f52154a8b00d818392b61e4b42b4",
 			})
 		}
+		// the "StoreLatestOnchainState" function is responsible of making a deep copy of all
+		// current validator data and storing it in the new "state.CommitedStates" map, which
+		// contains all the past onchain states of the validators.
+		// each time we store a new latestOnchainState, the merkleroot has changed, so we
+		// store a new state of all the validators.
+		// in a year, will update the onchain state 121 times. each time we do this, we will
+		// store the last onchain state, which contains the information of all the validators
 		state.StoreLatestOnchainState()
 	}
 
+	//after 1 year, we will have 121 states in the "state.CommitedStates" map.
+	//each state contains the information of 2000 validators.
+
+	//save the state to a file
 	state.SaveStateToFile()
 	filePath := "oracle-data/state.gob"
 


### PR DESCRIPTION
This PR contains a new functionality and two new tests to test it.

**Functionality:**
**Add new field on OracleState `CommitedStates map[string]OnchainState` that saves all commited states to the chain by their  merkle root.**  This change adds a lot of size to the OracleState, since each OnchainState has a copy of all the Validators and their information (including all blocks proposed by each validator), and this could be stored 1 time a day.

**Tests:**
**1:** **A test that checks the size of the OracleState when uploading the state of 2000 validators once every 3 days.** The test does the following:
- **Initializes an OracleState** instance some basic configuration values.
- Prepares 2000 validators with unique index values.
- **Subscribes all 2000 validators** with the same withdrawal address.
- Simulates a scenario where, **over the course of one year, 121 states are committed to the chain**. Each state represents the information of 2000 validators. **Within each state commit, 100 blocks are handled**, (in a pool of 2000 validators, more less 34 blocks would be proposed x day, so 100 each 3 days approx) with each block being proposed by a validator and containing specific reward and withdrawal address information.
- The **_StoreLatestOnchainState()_** function is called to store a deep copy of the current validator data in the state.CommitedStates map.
- The file size of the saved state is calculated and printed.

Some results:
Running this test multiple times always returns the same size: 137MB. This means that in a pool with 2000 validators and uploading the state every 3 days, each year the state size in memory would grow by 137MB.

2: **A test that is capable of checking the size of X validators or X blocks, or a combination of the two is also added**

Some results:
State of 2000 "empty" (validators without proposed/missed/wrong blocks) = **0.75MB**
State of 1 validator with 2000 blocks proposed: **0.4MB**

_Both tests can be run with different configurations like number of validators and blocks proposed in order to check state size in multiple scenarios_