### PR TITLE
Handle race condition multi oracle with delay

### DIFF
--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       #- --updater-keystore-path=/keystore
       #- --updater-keystore-pass=${UPDATER_KEYSTORE_PASS}
       - --dry-run
-      - --log-level=info
+      - --log-level=debug
     ports:
       - 7300:7300
     volumes:


### PR DESCRIPTION
Multiple oracles are racing to update the root. Lets say we have m oracles with a quorum on n (n/m). The oracles will be racing to update the root and only n txs will go through and (m-n) will be reverted, as the new state will be consolidated. In order to avoid txs being reverted (which costs gas), we add a random sleep between 0 and 15 minutes to avoid a collision. This is not perfect, but it should be good enough. Statistically, it would be very improbable that n+1 oracles will wait the same amount of time producing a collision.