### PR TITLE
Add logs persistency on oracle-data/oracleLogs.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ deployments/teku
 deployments/postgres-data
 deployments/metabase-data
 deployments/.env
+deployments/oracle-data/oracleLogs.txt
 state.gob
 state.json
 state_unused.gob

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ deployments/teku
 deployments/postgres-data
 deployments/metabase-data
 deployments/.env
-deployments/oracle-data/oracleLogs.txt
+deployments/oracle-logs
 state.gob
 state.json
 state_unused.gob

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
     volumes:
       - ./oracle-data:/oracle-data
       - ./keystore:/keystore
+      - ./oracle-logs:/oracle-logs
 
   geth:
     image: "ethereum/client-go:v1.11.4"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -26,17 +27,21 @@ var SlotsInEpoch = uint64(32)
 // How often onchain validators are reloaded: 600 slots is 2 hours
 var UpdateValidatorsIntervalSlots = uint64(600)
 
+// logs file and path
+const logsName = "logs.txt"
+const logsPath = "oracle-logs"
+
 func main() {
 	//file is created if not exists, otherwise it appends errors to the existing file
 	//0666 means permisions to read and write to all users, but not execute
-	file, err := os.OpenFile("/oracle-data/oracleLogs.txt", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(filepath.Join(logsPath, logsName), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		log.Fatal("error opening or creating the oracleLogs.txt file: ", err)
 	}
 	defer file.Close()
 
 	// Create a MultiWriter with file and stdout
-	multiWriter := io.MultiWriter(file, os.Stdout)
+	multiWriter := io.MultiWriter(os.Stdout, file)
 	// Set log output to the MultiWriter
 	log.SetOutput(multiWriter)
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -26,6 +27,19 @@ var SlotsInEpoch = uint64(32)
 var UpdateValidatorsIntervalSlots = uint64(600)
 
 func main() {
+	//file is created if not exists, otherwise it appends errors to the existing file
+	//0666 means permisions to read and write to all users, but not execute
+	file, err := os.OpenFile("/oracle-data/oracleLogs.txt", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatal("error opening or creating the oracleLogs.txt file: ", err)
+	}
+	defer file.Close()
+
+	// Create a MultiWriter with file and stdout
+	multiWriter := io.MultiWriter(file, os.Stdout)
+	// Set log output to the MultiWriter
+	log.SetOutput(multiWriter)
+
 	// Load config from cli
 	cliCfg, err := config.NewCliConfig()
 	if err != nil {


### PR DESCRIPTION
Used "log.SetOutput()" method of logrus to implement oracle writing to logs both through stdout and a file inside the container at /oracle-data/oracleLogs.txt.

This way, logs are persisted even when deleting the oracle container, since the "/oracle-data" folder is being bind mounted on host filesystem.