### PR TITLE
Refactor sync checks

### DIFF
--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -191,7 +191,7 @@ func (o *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
 
 	// If the sync distance is greater than 5, the consensus client is not in sync
 	if consSync.SyncDistance > 5 {
-		log.Info("Consensus client not in sync, Current sync distance: %d slots", consSync.SyncDistance)
+		log.Info("Consensus client not in sync, Client is more than 5 slots behind")
 		return false, nil
 	}
 


### PR DESCRIPTION
By default, now AreNodesInSync() method returns true, (synced). It returns false if execution client is syncing (!= nil) or consensus client distance from chain is more than 5 blocks. Also added logs so oracle operator knows which client is out of sync