### PR TITLE
Change updater-keystore-path to updater-keystore-file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 
 type CliConfig struct {
 	DryRun            bool
-	UpdaterKeyPath    string
+	UpdaterKeyFile    string
 	UpdaterKeyPass    string
 	NumRetries        int
 	ConsensusEndpoint string
@@ -52,7 +52,7 @@ func NewCliConfig() (*CliConfig, error) {
 	// Optional flags:
 	var version = flag.Bool("version", false, "Prints the release version and exits")
 	var dryRun = flag.Bool("dry-run", false, "If enabled, the pool contract will not be updated")
-	var updaterKeystorePath = flag.String("updater-keystore-path", "", "Path to the password-protected keystore file of the updater")
+	var updaterKeystoreFile = flag.String("updater-keystore-file", "", "Password protected keystore file of the updater")
 	var updaterKeystorePass = flag.String("updater-keystore-pass", "", "Password of the updater keystore file")
 	var numRetries = flag.Int("num-retries", 0, "Number of retries for each interaction (consensus, execution): 0 infinite")
 	var logLevel = flag.String("log-level", "info", "Logging verbosity (trace, debug, info=default, warn, error, fatal, panic)")
@@ -74,7 +74,7 @@ func NewCliConfig() (*CliConfig, error) {
 
 	// Some simple cli argument validation
 
-	if !*dryRun && *updaterKeystorePath == "" {
+	if !*dryRun && *updaterKeystoreFile == "" {
 		return nil, errors.New("you must provide a keystore file to update the contract root")
 	}
 
@@ -82,7 +82,7 @@ func NewCliConfig() (*CliConfig, error) {
 		return nil, errors.New("you must provide a password for the keystore file")
 	}
 
-	if *dryRun && *updaterKeystorePath != "" {
+	if *dryRun && *updaterKeystoreFile != "" {
 		return nil, errors.New("you can't provide a keystore file in dry run mode")
 	}
 
@@ -96,7 +96,7 @@ func NewCliConfig() (*CliConfig, error) {
 
 	cliConf := &CliConfig{
 		DryRun:            *dryRun,
-		UpdaterKeyPath:    *updaterKeystorePath,
+		UpdaterKeyFile:    *updaterKeystoreFile,
 		UpdaterKeyPass:    *updaterKeystorePass,
 		NumRetries:        *numRetries,
 		ConsensusEndpoint: *consensusEndpoint,
@@ -114,7 +114,7 @@ func NewCliConfig() (*CliConfig, error) {
 func logConfig(cfg *CliConfig) {
 	log.WithFields(log.Fields{
 		"DryRun":            cfg.DryRun,
-		"UpdaterKeyPath":    cfg.UpdaterKeyPath,
+		"UpdaterKeyFile":    cfg.UpdaterKeyFile,
 		"UpdaterKeyPass":    "hidden",
 		"NumRetries":        cfg.NumRetries,
 		"ConsensusEndpoint": cfg.ConsensusEndpoint,

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -1004,7 +1004,7 @@ func (onchain *Onchain) GetConfigFromContract(
 		DryRun:                   cliCfg.DryRun,
 		NumRetries:               cliCfg.NumRetries,
 		UpdaterKeyPass:           cliCfg.UpdaterKeyPass,
-		UpdaterKeyPath:           cliCfg.UpdaterKeyPath,
+		UpdaterKeyFile:           cliCfg.UpdaterKeyFile,
 	}
 
 	return conf

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -91,7 +91,7 @@ type Config struct {
 	NumRetries               int      `json:"num_retries"`
 	CollateralInWei          *big.Int `json:"collateral_in_wei"`
 	UpdaterKeyPass           string   `json:"-"`
-	UpdaterKeyPath           string   `json:"-"`
+	UpdaterKeyFile           string   `json:"-"`
 }
 
 // All the events that the contract can emit

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -187,7 +187,7 @@ func Equals(a string, b string) bool {
 func DecryptKey(cfg *config.CliConfig) (*keystore.Key, error) {
 	// Only parse it not in dry run mode
 	if !cfg.DryRun {
-		jsonBytes, err := ioutil.ReadFile(cfg.UpdaterKeyPath)
+		jsonBytes, err := ioutil.ReadFile(cfg.UpdaterKeyFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read updater key file")
 		}


### PR DESCRIPTION
* Change updater-keystore-path to updater-keystore-file.
* Breaking `updater-keystore-path` is deprecated.