### PR TITLE
Enable multiple valpubkey in registeredrelays endpoint

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -33,6 +33,7 @@ type httpOkStatus struct {
 }
 
 type httpOkRelayersState struct {
+	ValPubKey            string      `json:"valpubkey"`
 	CorrectFeeRecipients bool        `json:"correct_fee_recipients"`
 	CorrectFeeRelays     []httpRelay `json:"correct_fee_relayers"`
 	WrongFeeRelays       []httpRelay `json:"wrong_fee_relayers"`


### PR DESCRIPTION
Endpoint checks fee recipient configured of all relays when a validator tries to subscribe, so the endpoint `registeredrelays/${valpubkey}` is called. To implement multiple subscriptions at once, we need to update said endpoint to permit multiple `${valpubkey}` (divided by ",") so the front end can make the check of all validators trying to subscribe at once.