### PR TITLE
Handle wrong withdrawal credentials

### DIFF
--- a/oracle/onchain_test.go
+++ b/oracle/onchain_test.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -81,6 +82,29 @@ func Test_FetchFromExecution(t *testing.T) {
 	//expectedValue, ok := new(big.Int).SetString("25893180161173005034", 10)
 	//require.True(t, ok)
 	//require.Equal(t, expectedValue, balance)
+}
+
+func Test_GetValidator(t *testing.T) {
+	if skip {
+		t.Skip("Skipping test")
+	}
+
+	var cfgOnchain = &config.CliConfig{
+		ConsensusEndpoint: "http://127.0.0.1:3500",
+		ExecutionEndpoint: "http://127.0.0.1:8545",
+	}
+	onChain, err := NewOnchain(cfgOnchain, nil)
+	require.NoError(t, err)
+
+	vals, err := onChain.GetFinalizedValidators()
+	require.NoError(t, err)
+
+	for _, valEl := range vals {
+		fmt.Println(valEl.Index)
+		fmt.Println("raw: ", hex.EncodeToString(valEl.Validator.WithdrawalCredentials[:]))
+		a, b := GetWithdrawalAndType(valEl)
+		fmt.Println(valEl.Index, " ", hex.EncodeToString(valEl.Validator.WithdrawalCredentials[:]), "  ", a, "  ", b)
+	}
 }
 
 func Test_IsAddressWhitelisted(t *testing.T) {

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -1336,7 +1336,13 @@ func GetWithdrawalAndType(validator *v1.Validator) (string, WithdrawalType) {
 	} else if utils.IsEth1Type(withdrawalCred) {
 		return "0x" + withdrawalCred[24:], Eth1Withdrawal
 	}
-	log.Fatal("withdrawal credentials are not a valid type: ", withdrawalCred)
+	// can happen if a validator sets wrong withdrawal credentials (not very likely)
+	// aka not respecting the 0x00 or 0x000000000000000000000000 prefixes
+	// only concerning if the validator is subscribed to the pool
+	log.WithFields(log.Fields{
+		"WithdrawalCredentials": withdrawalCred,
+		"ValidatorIndex":        validator.Index,
+	}).Warn("withdrawal credentials are not valid, leaving empty")
 	return "", 0
 }
 


### PR DESCRIPTION
Bug:
* A validator with wrong withdrawal credentials (not BLS or ETH1) type can cause the oracle to crash.
* Fixed by handling this case without panic, warning that its wrong and leaving it empty, since there is nothing we can do.
* Most likely this wont happen in mainnet but in prater there were 2 validators not respecting this. [Example](https://prater.beaconcha.in/validator/413545#blocks)