### PR TITLE
Add sender to API donations response

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -779,6 +779,7 @@ func (m *ApiService) handleMemoryDonations(w http.ResponseWriter, req *http.Requ
 			AmountWei: donation.DonationAmount.String(),
 			Block:     donation.Raw.BlockNumber,
 			TxHash:    donation.Raw.TxHash.String(),
+			Sender:    donation.Sender.String(),
 		})
 	}
 	m.respondOK(w, donations)

--- a/api/types.go
+++ b/api/types.go
@@ -115,6 +115,7 @@ type httpOkDonation struct {
 	AmountWei string `json:"amount_wei"`
 	Block     uint64 `json:"block_number"`
 	TxHash    string `json:"tx_hash"`
+	Sender    string `json:"sender"`
 }
 
 type httpOkBlock struct {


### PR DESCRIPTION
In the frontend, we want to display donations too: https://github.com/dappnode/mev-sp-fe/issues/30

Added sender address to the donations API response. The sender from each donation was already stored in the oracle state, we just weren't returning it in API. 

Tested locally okay. 

`/memory/donations` before:
![Screenshot_20231120_125309](https://github.com/dappnode/mev-sp-oracle/assets/36164126/166c6e29-4728-446c-9f18-372f00f5021a)

`/memory/donations` after:
![Screenshot_20231120_125334](https://github.com/dappnode/mev-sp-oracle/assets/36164126/5274b9f3-e9bd-4e89-b106-58a2a05f84d0)

Transaction in beaconcha.in:
https://prater.beaconcha.in/tx/0xb647b7c050625d565d8466db954fb6ee2976135ee12b82b25ac308e93fe3e1f4
