### PR TITLE
Fix bls proposals

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -840,12 +840,16 @@ func (or *Oracle) handleBlsCorrectBlockProposal(block SummarizedBlock) {
 	if block.BlockType != OkPoolProposalBlsKeys {
 		log.Fatal("Block type is not OkPoolProposalBlsKeys, BlockType: ", block.BlockType)
 	}
+	or.increaseAllPendingRewards(block.Reward)
+	or.state.ProposedBlocks = append(or.state.ProposedBlocks, block)
+
 	log.WithFields(log.Fields{
-		"BlockNumber":    block.Block,
-		"Slot":           block.Slot,
-		"ValidatorIndex": block.ValidatorIndex,
-	}).Warn("Block proposal was ok but bls keys are not supported, sending rewards to pool")
-	or.sendRewardToPool(block.Reward)
+		"Slot":       block.Slot,
+		"Block":      block.Block,
+		"ValIndex":   block.ValidatorIndex,
+		"RewardWei":  block.Reward,
+		"RewardType": block.RewardType.String(),
+	}).Info("[Reward] From BLS validator. Not supported so just splitting the rewards among all validators")
 }
 
 // Handles a manual subscription to the pool, meaning that an event from the smart contract


### PR DESCRIPTION
Description:
* Handle block proposals of validators with BLS withdrawal credentials. A rare case but now is handled properly, splitting the rewards among all validators subscribed into the pool.
* This should never happen in mainnet, since these validators (with bls credentials) are not allowed to subscribe to the pool.