### PR TITLE
Fetch validator state from given slot

### DIFF
--- a/main.go
+++ b/main.go
@@ -219,7 +219,6 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 
 	// Load all the validators from the beacon chain
 	onchain.RefreshBeaconValidators()
-	oracleInstance.SetBeaconValidators(onchain.Validators())
 
 	log.WithFields(log.Fields{
 		"LatestProcessedSlot": oracleInstance.State().LatestProcessedSlot,
@@ -280,7 +279,6 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 
 		if oracleInstance.State().LatestProcessedSlot%UpdateValidatorsIntervalSlots == 0 {
 			onchain.RefreshBeaconValidators()
-			oracleInstance.SetBeaconValidators(onchain.Validators())
 		}
 
 		// Every CheckPointSizeInSlots we commit the state given some conditions, starting from

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -134,6 +134,10 @@ type FullBlock struct {
 
 	// execution data: events (optional, only when the block was not missed)
 	Events *Events `json:"events"`
+
+	// Populated with the validators if there are sub/unsub events
+	ValidatorsSubs   []*v1.Validator `json:"validators_subs"`
+	ValidatorsUnsubs []*v1.Validator `json:"validators_unsubs"`
 }
 
 // Represents a block with information relevant for the pool, uses Fullblock


### PR DESCRIPTION
* Currently, the oracle checks the latest validator state (finalized) and uses it to decide if it can subscribe or not into the pool. For example, a slashed or exited validator can't subscribe into the pool.
* However, the oracle should not use the latest finalized state, but the state of the validator when it was subscribed. Example: If validator v subscribes to the pool at slot s, the oracle should use the state of that validator at state s and not the latest finalized one.
* This PR addresses that.
* Low impact, only problematic when syncing from scratch.