### PR TITLE
Add subscription type to "handleMemoryValidators"

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -495,6 +495,7 @@ func (m *ApiService) handleMemoryValidators(w http.ResponseWriter, req *http.Req
 			WithdrawalAddress:     v.WithdrawalAddress,
 			ValidatorIndex:        v.ValidatorIndex,
 			ValidatorKey:          v.ValidatorKey,
+			SubscriptionType:      v.SubscriptionType.String(),
 		})
 	}
 


### PR DESCRIPTION
The endpoint `/memory/validators` was returning an empty `SubcriptionType` because the value was not appended to the returned struct `httpOkValidatorInfo`