### PR TITLE
Add new api endpoint `/memory/validatorsbyindex`

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -140,6 +140,11 @@ type httpOkValidatorInfo struct {
 	SubscriptionType      string `json:"subscription_type"`
 }
 
+type httpOkValidatorsByIndex struct {
+	Found    []httpOkValidatorInfo `json:"found_validators"`
+	NotFound []uint64              `json:"not_found_validators"`
+}
+
 // Subscription event and the associated validator (if any)
 // TODO: Perhaps remove, no longer need if refactored a bit
 type Subscription struct { //TODO: remove


### PR DESCRIPTION
Implemented new endpoint `/memory/validatorsbyindex/<indices>` 

The endpoint returns two arrays: 
- `found_validators`: array of validatorInfo (index,pubkey,status) of all validators found in oracle state
-  `not_found_validators`. array of index of all validators not found in oracle state