### PR TITLE
Fix nil receipts when no transactions

### DIFF
--- a/main.go
+++ b/main.go
@@ -279,24 +279,25 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 
 			// From time to time we do onchain reconciliation to ensure our assets match our liablities
 			if time.Now().Unix()-lastReconciliationTime > (ReconciliationEveryHours * 3600) {
-				log.Info("Running onchain reconciliation. Last one was: ", lastReconciliationTime)
-				lastReconciliationTime = time.Now().Unix()
+				// TODO: Temporally commented. Doesn't work well with non archival node
+				//log.Info("Running onchain reconciliation. Last one was: ", lastReconciliationTime)
+				//lastReconciliationTime = time.Now().Unix()
 
 				// If we are up to date, this is the latest finalized block. Run this only in the last block, otherwise
 				// a non archival node will error "missing trie node". Non archival nodes don't store much before last
 				// finalized block.
-				finalizedBlock := big.NewInt(0).SetUint64(oracleInstance.State().LatestProcessedBlock)
-				uniqueAddresses := oracleInstance.GetUniqueWithdrawalAddresses()
-				poolEthBalanceWei, err := onchain.GetPoolEthBalance(finalizedBlock)
-				if err != nil {
-					log.Fatal("Could not get pool eth balance for reconciliation: ", err)
-				}
+				//finalizedBlock := big.NewInt(0).SetUint64(oracleInstance.State().LatestProcessedBlock)
+				//uniqueAddresses := oracleInstance.GetUniqueWithdrawalAddresses()
+				//poolEthBalanceWei, err := onchain.GetPoolEthBalance(finalizedBlock)
+				//if err != nil {
+				//	log.Fatal("Could not get pool eth balance for reconciliation: ", err)
+				//}
 
-				claimedPerAccount := onchain.GetClaimedPerWithdrawalAddress(uniqueAddresses, finalizedBlock)
-				err = oracleInstance.RunOnchainReconciliation(poolEthBalanceWei, claimedPerAccount)
-				if err != nil {
-					log.Fatal("Reconciliation failed, state was not commited: ", err)
-				}
+				//claimedPerAccount := onchain.GetClaimedPerWithdrawalAddress(uniqueAddresses, finalizedBlock)
+				//err = oracleInstance.RunOnchainReconciliation(poolEthBalanceWei, claimedPerAccount)
+				//if err != nil {
+				//	log.Fatal("Reconciliation failed, state was not commited: ", err)
+				//}
 			}
 
 			time.Sleep(1 * time.Minute)
@@ -320,24 +321,25 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 				"DeployedSlot":          oracleInstance.State().DeployedSlot,
 			}).Info("Checkpoint reached")
 
-			log.Info("Running onchain reconciliation. Last one was: ", lastReconciliationTime)
-			lastReconciliationTime = time.Now().Unix()
+			// TODO: Temporally commented. Doesn't work well with non archival node
+			//log.Info("Running onchain reconciliation. Last one was: ", lastReconciliationTime)
+			//lastReconciliationTime = time.Now().Unix()
 
 			// If we are up to date, this is the latest finalized block. Run this only in the last block, otherwise
 			// a non archival node will error "missing trie node". Non archival nodes don't store much before last
 			// finalized block.
-			finalizedBlock := big.NewInt(0).SetUint64(oracleInstance.State().LatestProcessedBlock)
-			uniqueAddresses := oracleInstance.GetUniqueWithdrawalAddresses()
-			poolEthBalanceWei, err := onchain.GetPoolEthBalance(finalizedBlock)
-			if err != nil {
-				log.Fatal("Could not get pool eth balance for reconciliation: ", err)
-			}
+			//finalizedBlock := big.NewInt(0).SetUint64(oracleInstance.State().LatestProcessedBlock)
+			//uniqueAddresses := oracleInstance.GetUniqueWithdrawalAddresses()
+			//poolEthBalanceWei, err := onchain.GetPoolEthBalance(finalizedBlock)
+			//if err != nil {
+			//	log.Fatal("Could not get pool eth balance for reconciliation: ", err)
+			//}
 
-			claimedPerAccount := onchain.GetClaimedPerWithdrawalAddress(uniqueAddresses, finalizedBlock)
-			err = oracleInstance.RunOnchainReconciliation(poolEthBalanceWei, claimedPerAccount)
-			if err != nil {
-				log.Fatal("Reconciliation failed, state was not commited: ", err)
-			}
+			//claimedPerAccount := onchain.GetClaimedPerWithdrawalAddress(uniqueAddresses, finalizedBlock)
+			//err = oracleInstance.RunOnchainReconciliation(poolEthBalanceWei, claimedPerAccount)
+			//if err != nil {
+			//	log.Fatal("Reconciliation failed, state was not commited: ", err)
+			//}
 
 			err = oracleInstance.RunOffchainReconciliation()
 			if err != nil {

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -399,7 +399,7 @@ func (o *Onchain) GetExecHeaderAndReceipts(
 		return nil, nil, errors.New("Could not fetch header for block " + blockNumber.String() + ": " + err.Error())
 	}
 
-	var receipts []*types.Receipt
+	var receipts []*types.Receipt = make([]*types.Receipt, 0)
 	for _, rawTx := range rawTxs {
 		// This should never happen
 		tx, err := utils.DecodeTx(rawTx)


### PR DESCRIPTION
When a block contained no transactions, the node was panicking since a variable was uninitialized. This PR fixes it by initializing it, so that even if no transactions are present, its not nil but an empty slice.