### PR TITLE
Dont distribute to validators not in status "activeOngoing"

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,8 @@ func main() {
 	cfg := onchain.GetConfigFromContract(cliCfg)
 
 	// Create the oracle instance
-	oracleInstance := oracle.NewOracle(cfg, onchain)
+	oracleInstance := oracle.NewOracle(cfg)
+	oracleInstance.SetOnchain(onchain)
 
 	// If checkpoint sync url is provided, load state from it
 	if cliCfg.CheckPointSyncUrl != "" {

--- a/main.go
+++ b/main.go
@@ -224,7 +224,6 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 	lastReconciliationTime := int64(0)
 
 	// Load all the validators from the beacon chain
-	// TODO: see what API endpoints are affected by commenting this
 	onchain.RefreshBeaconValidators()
 
 	log.WithFields(log.Fields{

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	cfg := onchain.GetConfigFromContract(cliCfg)
 
 	// Create the oracle instance
-	oracleInstance := oracle.NewOracle(cfg)
+	oracleInstance := oracle.NewOracle(cfg, onchain)
 
 	// If checkpoint sync url is provided, load state from it
 	if cliCfg.CheckPointSyncUrl != "" {

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 
 	// Create the oracle instance
 	oracleInstance := oracle.NewOracle(cfg)
-	oracleInstance.SetOnchain(onchain)
+	oracleInstance.SetGetSetOfValidatorsFunc(onchain.GetSetOfValidators)
 
 	// If checkpoint sync url is provided, load state from it
 	if cliCfg.CheckPointSyncUrl != "" {
@@ -315,7 +315,7 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 
 			// Do the validator cleanup: redisitribute the pending rewards of validators subscribed to the pool
 			// that are not in the beacon chain anymore (e.g. slashed)
-			err := oracleInstance.ValidatorCleanup(finalizedBlockHeader)
+			err := oracleInstance.ValidatorCleanup(oracleInstance.State().LatestProcessedSlot)
 			// As precaution, we stop the oracle if anything happened during the cleanup
 			if err != nil {
 				log.Fatal("Could not cleanup validators: ", err)

--- a/main.go
+++ b/main.go
@@ -223,7 +223,8 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 	lastReconciliationTime := int64(0)
 
 	// Load all the validators from the beacon chain
-	onchain.RefreshBeaconValidators()
+	// TODO: see what API endpoints are affected by commenting this
+	// onchain.RefreshBeaconValidators()
 
 	log.WithFields(log.Fields{
 		"LatestProcessedSlot": oracleInstance.State().LatestProcessedSlot,
@@ -308,8 +309,10 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 			continue
 		}
 
+		// Every X slots we update the onchain validators and cleanup any stranded oracle validators
 		if oracleInstance.State().LatestProcessedSlot%UpdateValidatorsIntervalSlots == 0 {
 			onchain.RefreshBeaconValidators()
+			oracleInstance.ValidatorCleanup(finalizedBlockHeader)
 		}
 
 		// Every CheckPointSizeInSlots we commit the state given some conditions, starting from

--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 
 	// Load all the validators from the beacon chain
 	// TODO: see what API endpoints are affected by commenting this
-	// onchain.RefreshBeaconValidators()
+	onchain.RefreshBeaconValidators()
 
 	log.WithFields(log.Fields{
 		"LatestProcessedSlot": oracleInstance.State().LatestProcessedSlot,
@@ -312,6 +312,8 @@ func mainLoop(oracleInstance *oracle.Oracle, onchain *oracle.Onchain, cfg *oracl
 		// Every X slots we update the onchain validators and cleanup any stranded oracle validators
 		if oracleInstance.State().LatestProcessedSlot%UpdateValidatorsIntervalSlots == 0 {
 			onchain.RefreshBeaconValidators()
+
+			// This doesnt depend on the validators loaded in the onchain object
 			oracleInstance.ValidatorCleanup(finalizedBlockHeader)
 		}
 

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -64,6 +64,11 @@ type Onchain struct {
 	validators      map[phase0.ValidatorIndex]*v1.Validator
 }
 
+// ValidatorAccessor is an interface to access only the validators map
+type ValidatorAccessor interface {
+	GetValidators() map[phase0.ValidatorIndex]*v1.Validator
+}
+
 func NewOnchain(cliCfg *config.CliConfig, updaterKey *ecdsa.PrivateKey) (*Onchain, error) {
 
 	// Dial the execution client
@@ -155,6 +160,10 @@ func NewOnchain(cliCfg *config.CliConfig, updaterKey *ecdsa.PrivateKey) (*Onchai
 	}, nil
 }
 
+func (o *Onchain) GetValidators() map[phase0.ValidatorIndex]*v1.Validator {
+	return o.validators
+}
+
 func (o *Onchain) AreNodesInSync(opts ...retry.Option) (bool, error) {
 	var err error
 	var execSync *ethereum.SyncProgress
@@ -234,6 +243,7 @@ func (o *Onchain) GetConsensusBlockAtSlot(slot uint64, opts ...retry.Option) (*s
 	return signedBeaconBlock.Data, err
 }
 
+// Gets active validators by asking the chain. It does not get current Onchain object validators
 func (o *Onchain) GetFinalizedValidators(opts ...retry.Option) (map[phase0.ValidatorIndex]*v1.Validator, error) {
 	var validators *api.Response[map[phase0.ValidatorIndex]*v1.Validator]
 	var err error

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -64,11 +64,6 @@ type Onchain struct {
 	validators      map[phase0.ValidatorIndex]*v1.Validator
 }
 
-// ValidatorAccessor is an interface to access only the validators map
-type ValidatorAccessor interface {
-	GetSetOfValidators(valIndices []phase0.ValidatorIndex, slot string, opts ...retry.Option) (map[phase0.ValidatorIndex]*v1.Validator, error)
-}
-
 func NewOnchain(cliCfg *config.CliConfig, updaterKey *ecdsa.PrivateKey) (*Onchain, error) {
 
 	// Dial the execution client

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -323,67 +323,49 @@ func (o *Onchain) GetSingleValidator(valIndex phase0.ValidatorIndex, slot string
 	return validator, err
 }
 func (o *Onchain) GetSetOfValidators(valIndices []phase0.ValidatorIndex, slot string, opts ...retry.Option) (map[phase0.ValidatorIndex]*v1.Validator, error) {
-	// Chunk size for validator indices. TODO: move this elsewhere?
-	const chunkSize = 500
-
-	// This will hold the accumulated validators from all chunks
-	allValidators := make(map[phase0.ValidatorIndex]*v1.Validator)
-
 	// If empty, return an error. We do this to avoid fetching all validators. GetSetOfValidators should be used with a set of indices
 	if len(valIndices) == 0 {
 		return nil, errors.New("Error: validator indices are empty")
 	}
 
-	// Iterate over the validator indices in chunks of chunkSize. We avoid fetching all
-	// validators at once to avoid hitting the max URL length when calling o.ConsensusClient.Validators
-	for i := 0; i < len(valIndices); i += chunkSize {
-		end := i + chunkSize
-		if end > len(valIndices) {
-			end = len(valIndices)
-		}
-		indicesChunk := valIndices[i:end]
+	// Fetch all validators at once
+	var validators *api.Response[map[phase0.ValidatorIndex]*v1.Validator]
+	var err error
 
-		var validators *api.Response[map[phase0.ValidatorIndex]*v1.Validator]
-		var err error
+	err = retry.Do(func() error {
+		// Fetch all validators at once. Library will automatically batch the requests
+		validators, err = o.ConsensusClient.Validators(context.Background(), &api.ValidatorsOpts{
+			State:   slot,
+			Indices: valIndices,
+		})
 
-		err = retry.Do(func() error {
-			validators, err = o.ConsensusClient.Validators(context.Background(), &api.ValidatorsOpts{
-				State:   slot,
-				Indices: indicesChunk,
-			})
-
-			if err != nil {
-				log.Warn("Failed attempt to fetch validators: ", err.Error(), " Retrying...")
-				return errors.New("Error fetching validators: " + err.Error())
-			}
-
-			return nil
-		}, o.GetRetryOpts(opts)...)
-
-		// If there was an error fetching the validators, return it.
 		if err != nil {
-			return nil, errors.New("Could not fetch validators: " + err.Error())
+			log.Warn("Failed attempt to fetch validators: ", err.Error(), " Retrying...")
+			return errors.New("Error fetching validators: " + err.Error())
 		}
 
-		// If the data is empty, return an error. This should never happen.
-		if len(validators.Data) == 0 {
-			return nil, errors.New("Error: validator indices are empty") // No validators found
-		}
+		return nil
+	}, o.GetRetryOpts(opts)...)
 
-		// Add the fetched validators to the allValidators map
-		for idx, validator := range validators.Data {
-			allValidators[idx] = validator
-		}
+	// If there was an error fetching the validators, return it.
+	if err != nil {
+		return nil, errors.New("Could not fetch validators: " + err.Error())
+	}
 
-		// Sanity checks - Ensure all requested validators are found
-		for _, idx := range indicesChunk {
-			if _, found := validators.Data[idx]; !found {
-				return nil, errors.New(fmt.Sprintf("Error fetching validators: Could not find index in response: %d", idx))
-			}
+	// If the data is empty, return an error. This should never happen.
+	if len(validators.Data) == 0 {
+		return nil, errors.New("Error: no validators found onchain for the given indices")
+	}
+
+
+	// Sanity checks - Ensure all requested validators are found
+	for _, idx := range valIndices {
+		if _, found := validators.Data[idx]; !found {
+			return nil, errors.New(fmt.Sprintf("Error fetching validators: Could not find index in response: %d", idx))
 		}
 	}
 
-	return allValidators, nil
+	return validators.Data, nil
 }
 
 

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -37,8 +37,6 @@ const (
 	Untracked     ValidatorStatus = 6
 )
 
-const MainnetCleanupValidatorsSlot = uint64(10023371) // TODO: Define a slot
-
 // Events in the state machine that trigger transition
 type Event uint8
 

--- a/oracle/types.go
+++ b/oracle/types.go
@@ -37,6 +37,8 @@ const (
 	Untracked     ValidatorStatus = 6
 )
 
+const MainnetCleanupValidatorsSlot = uint64(10023371) // TODO: Define a slot
+
 // Events in the state machine that trigger transition
 type Event uint8
 


### PR DESCRIPTION
Closes https://github.com/dappnode/mev-sp-oracle/issues/227

* Every given interval, slashed and exited validators subscribed to the pool are unsubscribed, splitting their pending rewards to the rest of the validators.