### PR TITLE
Fix mev reward due to missing event

### DIFF
--- a/oracle/onchain_test.go
+++ b/oracle/onchain_test.go
@@ -138,6 +138,30 @@ func Test_BlocksWithInternalTx(t *testing.T) {
 	require.Equal(t, 0, len(donations))
 }
 
+func Test_BlocksWithInternalTx2(t *testing.T) {
+	t.Skip("Skipping test")
+
+	pool := "0xAdFb8D27671F14f297eE94135e266aAFf8752e35"
+	var cfgOnchain = &config.CliConfig{
+		ConsensusEndpoint: "http://127.0.0.1:3500",
+		ExecutionEndpoint: "http://127.0.0.1:8545",
+		PoolAddress:       pool,
+	}
+	onchain, err := NewOnchain(cfgOnchain, nil)
+	require.NoError(t, err)
+	oracle := NewOracle(&Config{})
+
+	// Self destruct that does not trigger EtherReceived event
+	// https://etherscan.io/tx/0x60571ab93a187c7e8f8ae7952430a7de64b47843e716cbd53a0fa741316569c6
+	fullBlock := onchain.FetchFullBlock(ExceptionSlotMainnet1, oracle)
+	donations := fullBlock.GetDonations(pool)
+	mevReward, isMev, recipient := fullBlock.MevRewardInWei()
+	require.Equal(t, big.NewInt(0).SetUint64(177043568463114308), mevReward)
+	require.Equal(t, true, isMev)
+	require.Equal(t, "0xAdFb8D27671F14f297eE94135e266aAFf8752e35", recipient)
+	require.Equal(t, 0, len(donations))
+}
+
 func Test_GetValidator(t *testing.T) {
 	if skip {
 		t.Skip("Skipping test")


### PR DESCRIPTION
* Slot [10400574](https://beaconcha.in/slot/10400574) had a MEV reward but the `EtherReceived` event was not triggered due to a self-destruct.
* This caused the reconciliation to fail. Ether arrived to the pool but it wasn't detected by the oracle.
* It also unfairly banned the validator. It sent the reward but since it wasn't detected, it was wrongly considered as having a wrong fee recipient.
* This PR temporally fixes this problem by hardcoding the mev reward for that block and the fee recipient.