### PR TITLE
Print electra shares only on trace.

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -1568,7 +1568,7 @@ func (or *Oracle) handleElectraRewardDistribution(
 			"TotalEffectiveBalance":     totalBalance,
 			"RewardToDistribute":        toDistribute,
 			"Share":                     share,
-		}).Info("[ELECTRA] Validator share")
+		}).Trace("[ELECTRA] Validator share")
 
 		perValidatorRewards[uint64(v.Index)] = share
 		totalDistributed.Add(totalDistributed, share)


### PR DESCRIPTION
Avoid spamming logs with shares of all validators in the pool each time a block is proposed, as oracle is often run in "info" or "debug" mode.

- validator share moved from "info" to "trace"
