### PR TITLE
fee change fixes

### DIFF
--- a/oracle/fee_schedule_test.go
+++ b/oracle/fee_schedule_test.go
@@ -1,0 +1,642 @@
+package oracle
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"testing"
+
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/dappnode/mev-sp-oracle/contract"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create a minimal Config for testing
+func testConfig(network string, fee int) *Config {
+	return &Config{
+		Network:                  network,
+		PoolAddress:              "0x0000000000000000000000000000000000000001",
+		PoolFeesAddress:          "0x0000000000000000000000000000000000000002",
+		PoolFeesPercentOver10000: fee,
+		CheckPointSizeInSlots:    100,
+		CollateralInWei:          big.NewInt(1000),
+		DeployedSlot:             1000,
+		DeployedBlock:            1000,
+	}
+}
+
+// Helper to create a minimal Oracle for testing
+func testOracle(network string, fee int) *Oracle {
+	cfg := testConfig(network, fee)
+	return NewOracle(cfg)
+}
+
+// Helper to create a FullBlock with an UpdatePoolFee event at a given slot
+func fullBlockWithFeeEvent(slot uint64, newFee int64) *FullBlock {
+	return &FullBlock{
+		ConsensusDuty: &v1.ProposerDuty{
+			Slot: phase0.Slot(slot),
+		},
+		Events: &Events{
+			UpdatePoolFee: []*contract.ContractUpdatePoolFee{
+				{NewPoolFee: big.NewInt(newFee)},
+			},
+		},
+	}
+}
+
+// Helper to create a FullBlock with no events at a given slot
+func fullBlockNoEvents(slot uint64) *FullBlock {
+	return &FullBlock{
+		ConsensusDuty: &v1.ProposerDuty{
+			Slot: phase0.Slot(slot),
+		},
+		Events: &Events{},
+	}
+}
+
+// Helper: serialize a state, compute its hash, set it, and return the bytes.
+// Mimics what SaveToJson does.
+func serializeStateWithHash(state *OracleState) ([]byte, error) {
+	state.StateHash = ""
+	jsonNoHash, err := json.MarshalIndent(state, "", " ")
+	if err != nil {
+		return nil, err
+	}
+	hashByte := sha256.Sum256(jsonNoHash)
+	state.StateHash = hexutil.Encode(hashByte[:])
+	jsonWithHash, err := json.MarshalIndent(state, "", " ")
+	if err != nil {
+		return nil, err
+	}
+	return jsonWithHash, nil
+}
+
+// =============================================================================
+// getFeeSchedule tests
+// =============================================================================
+
+func Test_getFeeSchedule_KnownNetwork(t *testing.T) {
+	schedule := getFeeSchedule(Mainnet)
+	require.NotEmpty(t, schedule)
+	fee, ok := schedule[14082460]
+	require.True(t, ok)
+	require.Equal(t, 500, fee)
+}
+
+func Test_getFeeSchedule_KnownNetworkHoodi(t *testing.T) {
+	schedule := getFeeSchedule(Hoodi)
+	require.NotEmpty(t, schedule)
+	fee, ok := schedule[2801050]
+	require.True(t, ok)
+	require.Equal(t, 500, fee)
+}
+
+func Test_getFeeSchedule_UnknownNetwork(t *testing.T) {
+	schedule := getFeeSchedule("unknown_network")
+	require.Empty(t, schedule)
+}
+
+// =============================================================================
+// applyFeeScheduleUpTo tests
+// =============================================================================
+
+func Test_applyFeeScheduleUpTo_BeforeAnyChange(t *testing.T) {
+	cfg := testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 10000000) // before slot 14082460
+	require.Equal(t, 700, cfg.PoolFeesPercentOver10000, "fee should remain initial value")
+}
+
+func Test_applyFeeScheduleUpTo_ExactlyAtChange(t *testing.T) {
+	cfg := testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 14082460)
+	require.Equal(t, 500, cfg.PoolFeesPercentOver10000, "fee should be updated to 500")
+}
+
+func Test_applyFeeScheduleUpTo_AfterChange(t *testing.T) {
+	cfg := testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 20000000)
+	require.Equal(t, 500, cfg.PoolFeesPercentOver10000, "fee should be updated to 500")
+}
+
+func Test_applyFeeScheduleUpTo_UnknownNetwork(t *testing.T) {
+	cfg := testConfig("goerli", 1000)
+	applyFeeScheduleUpTo(cfg, 99999999)
+	require.Equal(t, 1000, cfg.PoolFeesPercentOver10000, "fee should remain unchanged for unknown network")
+}
+
+func Test_applyFeeScheduleUpTo_MultipleEntries_PicksLatest(t *testing.T) {
+	// Temporarily add a second entry to test map ordering safety
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		14082460: 500,
+		20000000: 300,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	// Slot before all changes
+	cfg := testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 10000000)
+	require.Equal(t, 700, cfg.PoolFeesPercentOver10000)
+
+	// Slot between changes
+	cfg = testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 17000000)
+	require.Equal(t, 500, cfg.PoolFeesPercentOver10000)
+
+	// Slot after all changes — must pick highest qualifying (20000000 -> 300)
+	cfg = testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 25000000)
+	require.Equal(t, 300, cfg.PoolFeesPercentOver10000)
+
+	// Exactly at second change
+	cfg = testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 20000000)
+	require.Equal(t, 300, cfg.PoolFeesPercentOver10000)
+
+	// Exactly at first change (second doesn't apply yet)
+	cfg = testConfig(Mainnet, 700)
+	applyFeeScheduleUpTo(cfg, 14082460)
+	require.Equal(t, 500, cfg.PoolFeesPercentOver10000)
+}
+
+// Run the multi-entry test many times to catch Go map iteration randomness
+func Test_applyFeeScheduleUpTo_MultipleEntries_Deterministic(t *testing.T) {
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		14082460: 500,
+		20000000: 300,
+		25000000: 200,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	for i := 0; i < 100; i++ {
+		cfg := testConfig(Mainnet, 700)
+		applyFeeScheduleUpTo(cfg, 30000000)
+		require.Equal(t, 200, cfg.PoolFeesPercentOver10000,
+			fmt.Sprintf("iteration %d: should pick highest slot (25000000 -> 200)", i))
+	}
+}
+
+// =============================================================================
+// validateFullBlockConfig tests — UpdatePoolFee event handling
+// =============================================================================
+
+func Test_validateFullBlockConfig_ExpectedFeeChange(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	block := fullBlockWithFeeEvent(14082460, 500)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.NoError(t, err)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000, "config should be updated")
+	require.Equal(t, 500, oracle.state.PoolFeesPercentOver10000, "state should be updated")
+}
+
+func Test_validateFullBlockConfig_UnexpectedSlot(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	// Fee event at slot not in the schedule
+	block := fullBlockWithFeeEvent(99999999, 500)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected pool fee change")
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000, "config should be unchanged")
+	require.Equal(t, 700, oracle.state.PoolFeesPercentOver10000, "state should be unchanged")
+}
+
+func Test_validateFullBlockConfig_WrongFeeAtExpectedSlot(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	// Right slot but wrong fee value
+	block := fullBlockWithFeeEvent(14082460, 300)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected pool fee change")
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000, "config should be unchanged")
+}
+
+func Test_validateFullBlockConfig_NoFeeEvent(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	block := fullBlockNoEvents(14082460)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.NoError(t, err)
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000, "config should be unchanged when no event")
+}
+
+func Test_validateFullBlockConfig_HoodiExpectedFeeChange(t *testing.T) {
+	oracle := testOracle(Hoodi, 1000)
+
+	block := fullBlockWithFeeEvent(2801050, 500)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.NoError(t, err)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+	require.Equal(t, 500, oracle.state.PoolFeesPercentOver10000)
+}
+
+func Test_validateFullBlockConfig_MultipleFeeEventsInSameBlock(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	block := &FullBlock{
+		ConsensusDuty: &v1.ProposerDuty{
+			Slot: phase0.Slot(14082460),
+		},
+		Events: &Events{
+			UpdatePoolFee: []*contract.ContractUpdatePoolFee{
+				{NewPoolFee: big.NewInt(500)},
+				{NewPoolFee: big.NewInt(400)},
+			},
+		},
+	}
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "more than one event of the same type")
+}
+
+// =============================================================================
+// LoadFromBytes tests — state recovery with fee schedule reconciliation
+// =============================================================================
+
+func Test_LoadFromBytes_StateBefore_FeeChange(t *testing.T) {
+	// Config starts with initial fee 700
+	oracle := testOracle(Mainnet, 700)
+
+	// State saved before the fee change, fee=700
+	state := &OracleState{
+		LatestProcessedSlot:      10000000,
+		LatestProcessedBlock:     9000000,
+		NextSlotToProcess:        10000001,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 700,
+		PoolAddress:              oracle.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle.cfg.DeployedBlock,
+		DeployedSlot:             oracle.cfg.DeployedSlot,
+		CollateralInWei:          oracle.cfg.CollateralInWei,
+	}
+
+	rawBytes, err := serializeStateWithHash(state)
+	require.NoError(t, err)
+
+	found, err := oracle.LoadFromBytes(rawBytes)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000)
+	require.Equal(t, 700, oracle.state.PoolFeesPercentOver10000)
+}
+
+func Test_LoadFromBytes_StateAfter_FeeChange(t *testing.T) {
+	// Config starts with initial fee 700
+	oracle := testOracle(Mainnet, 700)
+
+	// State saved after the fee change, fee=500
+	state := &OracleState{
+		LatestProcessedSlot:      20000000,
+		LatestProcessedBlock:     18000000,
+		NextSlotToProcess:        20000001,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 500,
+		PoolAddress:              oracle.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle.cfg.DeployedBlock,
+		DeployedSlot:             oracle.cfg.DeployedSlot,
+		CollateralInWei:          oracle.cfg.CollateralInWei,
+	}
+
+	rawBytes, err := serializeStateWithHash(state)
+	require.NoError(t, err)
+
+	found, err := oracle.LoadFromBytes(rawBytes)
+	require.NoError(t, err)
+	require.True(t, found)
+	// Config should have been reconciled to 500 via applyFeeScheduleUpTo
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+	require.Equal(t, 500, oracle.state.PoolFeesPercentOver10000)
+}
+
+func Test_LoadFromBytes_StateExactlyAt_FeeChange(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	state := &OracleState{
+		LatestProcessedSlot:      14082460,
+		LatestProcessedBlock:     13000000,
+		NextSlotToProcess:        14082461,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 500,
+		PoolAddress:              oracle.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle.cfg.DeployedBlock,
+		DeployedSlot:             oracle.cfg.DeployedSlot,
+		CollateralInWei:          oracle.cfg.CollateralInWei,
+	}
+
+	rawBytes, err := serializeStateWithHash(state)
+	require.NoError(t, err)
+
+	found, err := oracle.LoadFromBytes(rawBytes)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+}
+
+func Test_LoadFromBytes_StateWithWrongFee_Rejected(t *testing.T) {
+	oracle := testOracle(Mainnet, 700)
+
+	// State claims fee=300 at slot 20000000, but schedule says 500 at that point
+	state := &OracleState{
+		LatestProcessedSlot:      20000000,
+		LatestProcessedBlock:     18000000,
+		NextSlotToProcess:        20000001,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 300, // wrong — schedule says 500 at this slot
+		PoolAddress:              oracle.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle.cfg.DeployedBlock,
+		DeployedSlot:             oracle.cfg.DeployedSlot,
+		CollateralInWei:          oracle.cfg.CollateralInWei,
+	}
+
+	rawBytes, err := serializeStateWithHash(state)
+	require.NoError(t, err)
+
+	_, err = oracle.LoadFromBytes(rawBytes)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pool fees percent mismatch")
+}
+
+func Test_LoadFromBytes_MultipleScheduleEntries(t *testing.T) {
+	// Add a second entry temporarily
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		14082460: 500,
+		20000000: 300,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	// State saved between changes: fee=500
+	oracle := testOracle(Mainnet, 700)
+	state := &OracleState{
+		LatestProcessedSlot:      17000000,
+		LatestProcessedBlock:     16000000,
+		NextSlotToProcess:        17000001,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 500,
+		PoolAddress:              oracle.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle.cfg.DeployedBlock,
+		DeployedSlot:             oracle.cfg.DeployedSlot,
+		CollateralInWei:          oracle.cfg.CollateralInWei,
+	}
+	rawBytes, err := serializeStateWithHash(state)
+	require.NoError(t, err)
+
+	found, err := oracle.LoadFromBytes(rawBytes)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+
+	// State saved after both changes: fee=300
+	oracle2 := testOracle(Mainnet, 700)
+	state2 := &OracleState{
+		LatestProcessedSlot:      25000000,
+		LatestProcessedBlock:     23000000,
+		NextSlotToProcess:        25000001,
+		PoolAccumulatedFees:      big.NewInt(0),
+		Validators:               make(map[uint64]*ValidatorInfo),
+		CommitedStates:           make(map[uint64]*OnchainState),
+		SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+		UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+		EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+		Donations:                make([]*contract.ContractEtherReceived, 0),
+		ProposedBlocks:           make([]SummarizedBlock, 0),
+		MissedBlocks:             make([]SummarizedBlock, 0),
+		WrongFeeBlocks:           make([]SummarizedBlock, 0),
+		PoolFeesPercentOver10000: 300,
+		PoolAddress:              oracle2.cfg.PoolAddress,
+		Network:                  Mainnet,
+		PoolFeesAddress:          oracle2.cfg.PoolFeesAddress,
+		CheckPointSizeInSlots:    oracle2.cfg.CheckPointSizeInSlots,
+		DeployedBlock:            oracle2.cfg.DeployedBlock,
+		DeployedSlot:             oracle2.cfg.DeployedSlot,
+		CollateralInWei:          oracle2.cfg.CollateralInWei,
+	}
+	rawBytes2, err := serializeStateWithHash(state2)
+	require.NoError(t, err)
+
+	found2, err := oracle2.LoadFromBytes(rawBytes2)
+	require.NoError(t, err)
+	require.True(t, found2)
+	require.Equal(t, 300, oracle2.cfg.PoolFeesPercentOver10000)
+}
+
+// Run the multi-entry LoadFromBytes test many times to catch map ordering issues
+func Test_LoadFromBytes_MultipleEntries_Deterministic(t *testing.T) {
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		14082460: 500,
+		20000000: 300,
+		25000000: 200,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	for i := 0; i < 100; i++ {
+		oracle := testOracle(Mainnet, 700)
+		state := &OracleState{
+			LatestProcessedSlot:      30000000,
+			LatestProcessedBlock:     28000000,
+			NextSlotToProcess:        30000001,
+			PoolAccumulatedFees:      big.NewInt(0),
+			Validators:               make(map[uint64]*ValidatorInfo),
+			CommitedStates:           make(map[uint64]*OnchainState),
+			SubscriptionEvents:       make([]*contract.ContractSubscribeValidator, 0),
+			UnsubscriptionEvents:     make([]*contract.ContractUnsubscribeValidator, 0),
+			EtherReceivedEvents:      make([]*contract.ContractEtherReceived, 0),
+			Donations:                make([]*contract.ContractEtherReceived, 0),
+			ProposedBlocks:           make([]SummarizedBlock, 0),
+			MissedBlocks:             make([]SummarizedBlock, 0),
+			WrongFeeBlocks:           make([]SummarizedBlock, 0),
+			PoolFeesPercentOver10000: 200,
+			PoolAddress:              oracle.cfg.PoolAddress,
+			Network:                  Mainnet,
+			PoolFeesAddress:          oracle.cfg.PoolFeesAddress,
+			CheckPointSizeInSlots:    oracle.cfg.CheckPointSizeInSlots,
+			DeployedBlock:            oracle.cfg.DeployedBlock,
+			DeployedSlot:             oracle.cfg.DeployedSlot,
+			CollateralInWei:          oracle.cfg.CollateralInWei,
+		}
+		rawBytes, err := serializeStateWithHash(state)
+		require.NoError(t, err)
+
+		found, err := oracle.LoadFromBytes(rawBytes)
+		require.NoError(t, err, "iteration %d", i)
+		require.True(t, found, "iteration %d", i)
+		require.Equal(t, 200, oracle.cfg.PoolFeesPercentOver10000,
+			"iteration %d: config fee should be 200 (latest schedule entry)", i)
+	}
+}
+
+// =============================================================================
+// End-to-end: simulate sequential slot processing across fee changes
+// =============================================================================
+
+func Test_SequentialFeeChanges(t *testing.T) {
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		100: 500,
+		200: 300,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	oracle := testOracle(Mainnet, 700)
+
+	// Slot before first change — no event
+	block := fullBlockNoEvents(50)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000)
+
+	// Slot at first change — event 700->500
+	block = fullBlockWithFeeEvent(100, 500)
+	err = oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+	require.Equal(t, 500, oracle.state.PoolFeesPercentOver10000)
+
+	// Slot between changes — no event
+	block = fullBlockNoEvents(150)
+	err = oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 500, oracle.cfg.PoolFeesPercentOver10000)
+
+	// Slot at second change — event 500->300
+	block = fullBlockWithFeeEvent(200, 300)
+	err = oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 300, oracle.cfg.PoolFeesPercentOver10000)
+	require.Equal(t, 300, oracle.state.PoolFeesPercentOver10000)
+
+	// Slot after all changes — no event
+	block = fullBlockNoEvents(300)
+	err = oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 300, oracle.cfg.PoolFeesPercentOver10000)
+}
+
+func Test_UnexpectedFeeChange_AtScheduledSlot_WrongFee(t *testing.T) {
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		100: 500,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	oracle := testOracle(Mainnet, 700)
+
+	// Event at the right slot but with wrong fee
+	block := fullBlockWithFeeEvent(100, 999)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected pool fee change")
+	require.Equal(t, 700, oracle.cfg.PoolFeesPercentOver10000, "config unchanged on error")
+}
+
+func Test_UnexpectedFeeChange_AtUnscheduledSlot(t *testing.T) {
+	origSchedule := feeSchedule[Mainnet]
+	feeSchedule[Mainnet] = map[uint64]int{
+		100: 500,
+	}
+	defer func() { feeSchedule[Mainnet] = origSchedule }()
+
+	oracle := testOracle(Mainnet, 700)
+
+	// Event at an unscheduled slot
+	block := fullBlockWithFeeEvent(999, 500)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected pool fee change")
+}
+
+// =============================================================================
+// Edge case: network with no schedule at all
+// =============================================================================
+
+func Test_NoSchedule_NoEvent_OK(t *testing.T) {
+	oracle := testOracle(Goerli, 1000)
+
+	block := fullBlockNoEvents(5000)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.NoError(t, err)
+	require.Equal(t, 1000, oracle.cfg.PoolFeesPercentOver10000)
+}
+
+func Test_NoSchedule_WithEvent_Rejected(t *testing.T) {
+	oracle := testOracle(Goerli, 1000)
+
+	block := fullBlockWithFeeEvent(5000, 500)
+	err := oracle.validateFullBlockConfig(block, oracle.cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected pool fee change")
+}

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dappnode/mev-sp-oracle/contract"
 	"github.com/dappnode/mev-sp-oracle/utils"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -398,47 +399,84 @@ func (o *Onchain) BlockByNumber(blockNumber *big.Int, opts ...retry.Option) (*ty
 
 // decodeInitialPoolFee extracts the _poolFee parameter from the initialize() transaction
 // in the deployment block. This works on full nodes since transaction data is stored in blocks.
+//
+// It handles two deployment patterns:
+//  1. Direct call: initialize() sent as a separate tx TO the pool address.
+//  2. Proxy constructor: a TransparentUpgradeableProxy is deployed in a single
+//     contract-creation tx; the initialize() calldata is embedded in the
+//     constructor arguments and executed via delegatecall during deployment.
 func decodeInitialPoolFee(block *types.Block, poolAddress string) (int, error) {
 	contractABI, err := contract.ContractMetaData.GetAbi()
 	if err != nil {
 		return 0, errors.Wrap(err, "could not parse contract ABI")
 	}
 
+	initMethod, ok := contractABI.Methods["initialize"]
+	if !ok {
+		return 0, errors.New("initialize method not found in contract ABI")
+	}
+	selector := initMethod.ID // 4-byte selector
+
 	poolAddr := common.HexToAddress(poolAddress)
 
 	for _, tx := range block.Transactions() {
-		if tx.To() == nil || *tx.To() != poolAddr {
-			continue
-		}
 		data := tx.Data()
 		if len(data) < 4 {
 			continue
 		}
 
-		method, err := contractABI.MethodById(data[:4])
-		if err != nil || method.Name != "initialize" {
-			continue
+		// Case 1: direct call to the pool address with initialize() selector.
+		if tx.To() != nil && *tx.To() == poolAddr {
+			method, err := contractABI.MethodById(data[:4])
+			if err != nil || method.Name != "initialize" {
+				continue
+			}
+			return decodePoolFeeFromInitArgs(initMethod, data[4:])
 		}
 
-		args, err := method.Inputs.Unpack(data[4:])
-		if err != nil {
-			return 0, errors.Wrap(err, "could not decode initialize() arguments")
+		// Case 2: contract-creation tx (proxy deployment). The initialize()
+		// calldata is passed as a constructor argument and appears embedded
+		// in the tx data. Scan for the 4-byte selector.
+		if tx.To() == nil {
+			if fee, err := findInitializeInCreationData(initMethod, selector, data); err == nil {
+				return fee, nil
+			}
 		}
-
-		// initialize(address _governance, uint256 _subscriptionCollateral, uint256 _poolFee, ...)
-		if len(args) < 3 {
-			return 0, errors.New("initialize() has fewer arguments than expected")
-		}
-
-		poolFee, ok := args[2].(*big.Int)
-		if !ok {
-			return 0, errors.New("could not cast _poolFee argument to *big.Int")
-		}
-
-		return int(poolFee.Int64()), nil
 	}
 
 	return 0, errors.New("initialize() transaction not found in deployment block")
+}
+
+// decodePoolFeeFromInitArgs ABI-decodes the initialize() arguments and returns _poolFee.
+func decodePoolFeeFromInitArgs(method abi.Method, argData []byte) (int, error) {
+	args, err := method.Inputs.Unpack(argData)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not decode initialize() arguments")
+	}
+	// initialize(address _governance, uint256 _subscriptionCollateral, uint256 _poolFee, ...)
+	if len(args) < 3 {
+		return 0, errors.New("initialize() has fewer arguments than expected")
+	}
+	poolFee, ok := args[2].(*big.Int)
+	if !ok {
+		return 0, errors.New("could not cast _poolFee argument to *big.Int")
+	}
+	return int(poolFee.Int64()), nil
+}
+
+// findInitializeInCreationData scans a contract-creation tx's data for an
+// embedded initialize() call (as seen in proxy constructor arguments).
+func findInitializeInCreationData(method abi.Method, selector []byte, data []byte) (int, error) {
+	for i := 0; i+4 <= len(data); i++ {
+		if data[i] == selector[0] && data[i+1] == selector[1] &&
+			data[i+2] == selector[2] && data[i+3] == selector[3] {
+			remaining := data[i+4:]
+			if fee, err := decodePoolFeeFromInitArgs(method, remaining); err == nil {
+				return fee, nil
+			}
+		}
+	}
+	return 0, errors.New("initialize() selector not found in contract creation data")
 }
 
 func (o *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*v1.ProposerDuty, error) {

--- a/oracle/onchain.go
+++ b/oracle/onchain.go
@@ -396,6 +396,51 @@ func (o *Onchain) BlockByNumber(blockNumber *big.Int, opts ...retry.Option) (*ty
 	return block, err
 }
 
+// decodeInitialPoolFee extracts the _poolFee parameter from the initialize() transaction
+// in the deployment block. This works on full nodes since transaction data is stored in blocks.
+func decodeInitialPoolFee(block *types.Block, poolAddress string) (int, error) {
+	contractABI, err := contract.ContractMetaData.GetAbi()
+	if err != nil {
+		return 0, errors.Wrap(err, "could not parse contract ABI")
+	}
+
+	poolAddr := common.HexToAddress(poolAddress)
+
+	for _, tx := range block.Transactions() {
+		if tx.To() == nil || *tx.To() != poolAddr {
+			continue
+		}
+		data := tx.Data()
+		if len(data) < 4 {
+			continue
+		}
+
+		method, err := contractABI.MethodById(data[:4])
+		if err != nil || method.Name != "initialize" {
+			continue
+		}
+
+		args, err := method.Inputs.Unpack(data[4:])
+		if err != nil {
+			return 0, errors.Wrap(err, "could not decode initialize() arguments")
+		}
+
+		// initialize(address _governance, uint256 _subscriptionCollateral, uint256 _poolFee, ...)
+		if len(args) < 3 {
+			return 0, errors.New("initialize() has fewer arguments than expected")
+		}
+
+		poolFee, ok := args[2].(*big.Int)
+		if !ok {
+			return 0, errors.New("could not cast _poolFee argument to *big.Int")
+		}
+
+		return int(poolFee.Int64()), nil
+	}
+
+	return 0, errors.New("initialize() transaction not found in deployment block")
+}
+
 func (o *Onchain) GetProposalDuty(slot uint64, opts ...retry.Option) (*v1.ProposerDuty, error) {
 	epoch := slot / constants.SlotsInEpoch
 	slotWithinEpoch := slot % constants.SlotsInEpoch
@@ -1132,17 +1177,30 @@ func (onchain *Onchain) GetConfigFromContract(
 
 	log.Info("[Loaded from contract] Contract deployed in slot: ", deployedSlot)
 
+	// Decode the initial pool fee from the initialize() transaction in the deployment block.
+	// This avoids hardcoding the initial fee and works on full nodes (no archive needed).
+	// If decoding fails, fall back to a network-specific default.
+	initialPoolFee, err := decodeInitialPoolFee(block, cliCfg.PoolAddress)
+	if err != nil {
+		defaultFees := map[string]int{
+			Mainnet: 700,  // 7%
+			Hoodi:   1000, // 10%
+		}
+		defaultFee, ok := defaultFees[network]
+		if !ok {
+			log.Fatal("Could not decode initial pool fee and no default configured for network ", network, ": ", err.Error())
+		}
+		initialPoolFee = defaultFee
+		log.Warn("Could not decode initial pool fee from deployment block (", err.Error(), "), using default for ", network, ": ", float64(initialPoolFee)/100, "%")
+	} else {
+		log.Info("[Decoded from deployment tx] Initial pool fees percent: ", float64(initialPoolFee)/100, "% (raw value: ", initialPoolFee, ")")
+	}
+
 	checkPointSizeInSlots, err := onchain.GetSlotCheckpointSize()
 	if err != nil {
 		log.Fatal("Could not get slot checkpoint size: " + err.Error())
 	}
 	log.Info("[Loaded from contract] Checkpoints will be created every ", checkPointSizeInSlots, " slots (", utils.SlotsToTime(checkPointSizeInSlots, constants.SecondsInSlot), ")")
-
-	poolFeesPercentTwoDecimals, err := onchain.GetPoolFee()
-	if err != nil {
-		log.Fatal("Could not get pool fee: " + err.Error())
-	}
-	log.Info("[Loaded from contract] Pool fees percent: ", float64(poolFeesPercentTwoDecimals.Uint64())/100, "% (raw value: ", poolFeesPercentTwoDecimals, ")")
 
 	poolFeesAddress, err := onchain.GetPoolFeeAddress()
 	if err != nil {
@@ -1184,7 +1242,7 @@ func (onchain *Onchain) GetConfigFromContract(
 		DeployedSlot:             deployedSlot,
 		DeployedBlock:            deployedBlock.Uint64(),
 		CheckPointSizeInSlots:    checkPointSizeInSlots,
-		PoolFeesPercentOver10000: int(poolFeesPercentTwoDecimals.Uint64()),
+		PoolFeesPercentOver10000: initialPoolFee,
 		PoolFeesAddress:          poolFeesAddress,
 		CollateralInWei:          ethCollateralInWei,
 		DryRun:                   cliCfg.DryRun,

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -402,8 +402,47 @@ func (or *Oracle) ValidatorCleanup(slot uint64) error {
 	return nil
 }
 
+// Known fee schedule per network: maps the slot where an expected fee change takes effect to the new fee value.
+// When the oracle processes a slot listed here, it updates the config and state.
+// If an UpdatePoolFee event is seen at a slot NOT in this schedule, the oracle crashes.
+// Add new entries here when planning a fee change on-chain.
+var feeSchedule = map[string]map[uint64]int{
+	Mainnet: {
+		14082460: 500, // block 24848448: 7% -> 5%
+	},
+	Hoodi: {
+		2801050: 500, // block 2589876: 10% -> 5%
+	},
+}
+
+// getFeeSchedule returns the fee schedule for the given network, or an empty map if none.
+func getFeeSchedule(network string) map[uint64]int {
+	if schedule, ok := feeSchedule[network]; ok {
+		return schedule
+	}
+	return map[uint64]int{}
+}
+
+// applyFeeScheduleUpTo applies the latest fee schedule entry with slot <= upToSlot to the config.
+// When multiple entries qualify, the one with the highest slot wins (most recent change).
+func applyFeeScheduleUpTo(config *Config, upToSlot uint64) {
+	bestSlot := uint64(0)
+	bestFee := 0
+	found := false
+	for slot, fee := range getFeeSchedule(config.Network) {
+		if slot <= upToSlot && (!found || slot > bestSlot) {
+			bestSlot = slot
+			bestFee = fee
+			found = true
+		}
+	}
+	if found {
+		config.PoolFeesPercentOver10000 = bestFee
+	}
+}
+
 // We use the following events to validate that the config has not changed. Dynamic
-// parameters are not supported.
+// parameters are not supported, except for known fee changes listed in feeSchedule.
 // UpdatePoolFee: Indicates the cut in %*100 the pool gets
 // PoolFeeRecipient: Indicates the address that receives the pool fees
 // CheckpointSlotSize: Indicates the size of the checkpoint in slots
@@ -416,9 +455,19 @@ func (or *Oracle) validateFullBlockConfig(fullBlock *FullBlock, config *Config) 
 		return errors.New("more than one event of the same type in the same block, weird")
 	}
 
-	if len(fullBlock.Events.UpdatePoolFee) != 0 && big.NewInt(int64(config.PoolFeesPercentOver10000)).Cmp(fullBlock.Events.UpdatePoolFee[0].NewPoolFee) != 0 {
-		return errors.New(fmt.Sprintf("pool fee has changed. config: %d, block: %d",
-			config.PoolFeesPercentOver10000, fullBlock.Events.UpdatePoolFee[0].NewPoolFee))
+	// If an UpdatePoolFee event is found, check if it's expected in the fee schedule.
+	// If expected, apply the new fee from the event. If not, crash.
+	if len(fullBlock.Events.UpdatePoolFee) != 0 {
+		slot := uint64(fullBlock.ConsensusDuty.Slot)
+		newFee := int(fullBlock.Events.UpdatePoolFee[0].NewPoolFee.Int64())
+		expectedFee, expected := getFeeSchedule(config.Network)[slot]
+		if !expected || expectedFee != newFee {
+			return errors.New(fmt.Sprintf("unexpected pool fee change at slot %d. event fee: %d, expected: %d (scheduled: %v)",
+				slot, newFee, expectedFee, expected))
+		}
+		log.Info("Applying expected fee change from UpdatePoolFee event at slot ", slot, ": ", config.PoolFeesPercentOver10000, " -> ", newFee)
+		config.PoolFeesPercentOver10000 = newFee
+		or.state.PoolFeesPercentOver10000 = newFee
 	}
 
 	if len(fullBlock.Events.PoolFeeRecipient) != 0 && !utils.Equals(config.PoolFeesAddress, fullBlock.Events.PoolFeeRecipient[0].NewPoolFeeRecipient.String()) {
@@ -587,8 +636,13 @@ func (or *Oracle) LoadFromBytes(rawBytes []byte) (bool, error) {
 	}
 
 	if state.PoolFeesPercentOver10000 != or.cfg.PoolFeesPercentOver10000 {
-		return false, errors.New(fmt.Sprintf("pool fees percent mismatch, recovered: %d, expected: %d",
-			state.PoolFeesPercentOver10000, or.cfg.PoolFeesPercentOver10000))
+		// The config starts at initialPoolFee. If the state was saved after a
+		// scheduled fee change, apply the schedule up to the state's slot.
+		applyFeeScheduleUpTo(or.cfg, state.LatestProcessedSlot)
+		if state.PoolFeesPercentOver10000 != or.cfg.PoolFeesPercentOver10000 {
+			return false, errors.New(fmt.Sprintf("pool fees percent mismatch, recovered: %d, expected: %d",
+				state.PoolFeesPercentOver10000, or.cfg.PoolFeesPercentOver10000))
+		}
 	}
 
 	if state.CollateralInWei.Cmp(or.cfg.CollateralInWei) != 0 {

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -1757,6 +1757,7 @@ func (or *Oracle) increaseAllPendingRewards(reward *big.Int) {
 	case RewardMethodElectra:
 		log.WithFields(log.Fields{
 			"AmountEligibleValidators": numEligibleValidators,
+			"PoolFeePercent":           fmt.Sprintf("%.2f%%", float64(or.state.PoolFeesPercentOver10000)/100),
 			"PoolFeesWei":              totalFees,
 			"TotalRewardWei":           reward,
 		}).Info("[PECTRA] Increasing pending rewards of eligible validators")
@@ -1768,6 +1769,7 @@ func (or *Oracle) increaseAllPendingRewards(reward *big.Int) {
 	case RewardMethodFork1, RewardMethodPreFork1:
 		log.WithFields(log.Fields{
 			"AmountEligibleValidators": numEligibleValidators,
+			"PoolFeePercent":           fmt.Sprintf("%.2f%%", float64(or.state.PoolFeesPercentOver10000)/100),
 			"RewardPerValidatorWei":    perValidatorReward,
 			"PoolFeesWei":              totalFees,
 			"TotalRewardWei":           reward,


### PR DESCRIPTION
This pull request introduces a robust mechanism for managing and validating pool fee changes in the oracle, making fee changes explicit, auditable, and network-specific. The main improvements include extracting the initial pool fee from the contract deployment transaction, enforcing a known fee schedule per network, and validating all fee changes against this schedule to prevent unexpected or unauthorized updates.

**Fee management and validation:**

* Added a `decodeInitialPoolFee` function to extract the initial pool fee from the `initialize()` transaction in the deployment block, avoiding hardcoded values and supporting full nodes (no archive node required). If decoding fails, a network-specific default is used. (`oracle/onchain.go`) [[1]](diffhunk://#diff-50e7e8c9ebde3c86e2e8fb607502007aa9e39ef74fa9facdbc7611fe25f20c73R399-R443) [[2]](diffhunk://#diff-50e7e8c9ebde3c86e2e8fb607502007aa9e39ef74fa9facdbc7611fe25f20c73L1135-R1203) [[3]](diffhunk://#diff-50e7e8c9ebde3c86e2e8fb607502007aa9e39ef74fa9facdbc7611fe25f20c73L1187-R1245)
* Introduced a `feeSchedule` map per network, defining at which slots fee changes are expected and what the new fee should be. Helper functions allow applying the correct fee based on slot number. (`oracle/oracle.go`)
* Updated the configuration loading and state restoration logic to apply scheduled fee changes up to the current slot, ensuring consistency between config and state. (`oracle/oracle.go`)

**Event validation and safety:**

* Modified the event validation logic so that only fee changes matching the schedule are allowed; any unexpected fee change event will cause the oracle to crash, enforcing strict control over fee updates. (`oracle/oracle.go`)

These changes make fee management explicit, auditable, and safer by preventing accidental or malicious fee changes outside of a pre-approved schedule.